### PR TITLE
obs-audio-capture.hpp: missing memory include

### DIFF
--- a/source/obs-audio-capture.hpp
+++ b/source/obs-audio-capture.hpp
@@ -19,6 +19,7 @@
 
 #pragma once
 #include <functional>
+#include <memory>
 #include "obs-source.hpp"
 
 // OBS


### PR DESCRIPTION
to declare the `shared_ptr` name