### PR TITLE
gfx-shader: Don't use modified_properties to reload shaders

### DIFF
--- a/data/locale/en-US.ini
+++ b/data/locale/en-US.ini
@@ -63,6 +63,7 @@ MipGenerator.Intensity.Description="Intensity of the generator."
 
 # Shader
 Shader="Shader"
+Shader.Refresh="Refresh Options and Parameters"
 Shader.Shader="Shader Options"
 Shader.Shader.File="File"
 Shader.Shader.Technique="Technique"

--- a/source/gfx/shader/gfx-shader.hpp
+++ b/source/gfx/shader/gfx-shader.hpp
@@ -65,7 +65,7 @@ namespace gfx {
 			// Cache
 			float_t         _time;
 			float_t         _time_loop;
-			int32_t			_loops;
+			int32_t         _loops;
 			std::mt19937_64 _random;
 			bool            _have_current_params;
 
@@ -84,7 +84,9 @@ namespace gfx {
 
 			void properties(obs_properties_t* props);
 
-			bool on_properties_modified(obs_properties_t* props, obs_property_t* prop, obs_data_t* data);
+			bool on_refresh_properties(obs_properties_t* props, obs_property_t* prop);
+
+			bool on_shader_or_technique_modified(obs_properties_t* props, obs_property_t* prop, obs_data_t* data);
 
 			bool update_shader(obs_data_t* data, bool& shader_dirty, bool& param_dirty);
 


### PR DESCRIPTION
### Description
As OBS Studio locks some mutexes in a different order depending on what actions are being done, using modified_properties for GPU work causes things to freeze in place. Instead have users manually click the refresh button when they changed files in order to prevent this freeze from happening.

Fixes: #118

### Motivation and Context
Freezes are annoying.

### How Has This Been Tested?
Dialog no longer freezes. Button correctly refreshes the UI.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
- Breaking change (fix or feature that would cause existing functionality to change)
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
