### PR TITLE
FFmpeg Encoders: Fix Look-Ahead and add extra feature support checks

### DIFF
--- a/source/encoders/handlers/handler.cpp
+++ b/source/encoders/handlers/handler.cpp
@@ -28,9 +28,24 @@ void encoder::ffmpeg::handler::handler::adjust_encoder_info(encoder::ffmpeg::ffm
 
 void encoder::ffmpeg::handler::handler::get_defaults(obs_data_t*, const AVCodec*, AVCodecContext*, bool) {}
 
-bool encoder::ffmpeg::handler::handler::has_keyframe_support(ffmpeg_instance* instance)
+bool encoder::ffmpeg::handler::handler::has_keyframe_support(ffmpeg_factory* instance)
 {
 	return (instance->get_avcodec()->capabilities & AV_CODEC_CAP_INTRA_ONLY) == 0;
+}
+
+bool encoder::ffmpeg::handler::handler::is_hardware_encoder(ffmpeg_factory* instance)
+{
+	return false;
+}
+
+bool encoder::ffmpeg::handler::handler::has_threading_support(ffmpeg_factory* instance)
+{
+	return (instance->get_avcodec()->capabilities & (AV_CODEC_CAP_FRAME_THREADS | AV_CODEC_CAP_SLICE_THREADS));
+}
+
+bool encoder::ffmpeg::handler::handler::has_pixel_format_support(ffmpeg_factory* instance)
+{
+	return (instance->get_avcodec()->pix_fmts != nullptr);
 }
 
 void encoder::ffmpeg::handler::handler::get_properties(obs_properties_t*, const AVCodec*, AVCodecContext*, bool) {}

--- a/source/encoders/handlers/handler.hpp
+++ b/source/encoders/handlers/handler.hpp
@@ -46,9 +46,16 @@ namespace encoder::ffmpeg {
 			virtual void get_defaults(obs_data_t* settings, const AVCodec* codec, AVCodecContext* context,
 									  bool hw_encode);
 
-			public /*settings*/:
-			virtual bool has_keyframe_support(ffmpeg_instance* instance);
+			public /*support tests*/:
+			virtual bool has_keyframe_support(ffmpeg_factory* instance);
 
+			virtual bool is_hardware_encoder(ffmpeg_factory* instance);
+
+			virtual bool has_threading_support(ffmpeg_factory* instance);
+
+			virtual bool has_pixel_format_support(ffmpeg_factory* instance);
+
+			public /*settings*/:
 			virtual void get_properties(obs_properties_t* props, const AVCodec* codec, AVCodecContext* context,
 										bool hw_encode);
 

--- a/source/encoders/handlers/nvenc_h264_handler.cpp
+++ b/source/encoders/handlers/nvenc_h264_handler.cpp
@@ -75,6 +75,21 @@ void nvenc_h264_handler::get_defaults(obs_data_t* settings, const AVCodec* codec
 	obs_data_set_default_int(settings, KEY_LEVEL, static_cast<int64_t>(level::UNKNOWN));
 }
 
+bool encoder::ffmpeg::handler::nvenc_h264_handler::is_hardware_encoder(ffmpeg_factory* instance)
+{
+	return true;
+}
+
+bool encoder::ffmpeg::handler::nvenc_h264_handler::has_threading_support(ffmpeg_factory* instance)
+{
+	return false;
+}
+
+bool encoder::ffmpeg::handler::nvenc_h264_handler::has_pixel_format_support(ffmpeg_factory* instance)
+{
+	return true;
+}
+
 bool nvenc_h264_handler::has_keyframe_support(ffmpeg_instance*)
 {
 	return true;

--- a/source/encoders/handlers/nvenc_h264_handler.hpp
+++ b/source/encoders/handlers/nvenc_h264_handler.hpp
@@ -39,9 +39,16 @@ namespace encoder::ffmpeg::handler {
 
 		virtual void get_defaults(obs_data_t* settings, const AVCodec* codec, AVCodecContext* context, bool hw_encode);
 
-		public /*settings*/:
+		public /*support tests*/:
 		virtual bool has_keyframe_support(ffmpeg_instance* instance);
 
+		virtual bool is_hardware_encoder(ffmpeg_factory* instance);
+
+		virtual bool has_threading_support(ffmpeg_factory* instance);
+
+		virtual bool has_pixel_format_support(ffmpeg_factory* instance);
+
+		public /*settings*/:
 		virtual void get_properties(obs_properties_t* props, const AVCodec* codec, AVCodecContext* context,
 									bool hw_encode);
 

--- a/source/encoders/handlers/nvenc_shared.cpp
+++ b/source/encoders/handlers/nvenc_shared.cpp
@@ -314,8 +314,8 @@ void nvenc::get_properties_post(obs_properties_t* props, const AVCodec* codec)
 		}
 
 		{
-			auto p = obs_properties_add_int_slider(grp, ST_RATECONTROL_LOOKAHEAD, D_TRANSLATE(ST_RATECONTROL_LOOKAHEAD),
-												   -1, 32, 1);
+			auto p = obs_properties_add_int_slider(grp, KEY_RATECONTROL_LOOKAHEAD,
+												   D_TRANSLATE(ST_RATECONTROL_LOOKAHEAD), -1, 32, 1);
 			obs_property_set_long_description(p, D_TRANSLATE(D_DESC(ST_RATECONTROL_LOOKAHEAD)));
 			obs_property_int_set_suffix(p, " frames");
 			//obs_property_set_modified_callback(p, modified_lookahead);
@@ -592,6 +592,12 @@ void nvenc::update(obs_data_t* settings, const AVCodec* codec, AVCodecContext* c
 					!util::is_tristate_default(adapt_b)) {
 					av_opt_set_int(context->priv_data, "b_adapt", adapt_b, AV_OPT_SEARCH_CHILDREN);
 				}
+			}
+		} else {
+			// These two do not work if lookahead is set to 0 frames (disabled).
+			av_opt_set_int(context->priv_data, "no-scenecut", 0, AV_OPT_SEARCH_CHILDREN);
+			if (strcmp(codec->name, "h264_nvenc")) {
+				av_opt_set_int(context->priv_data, "b_adapt", 0, AV_OPT_SEARCH_CHILDREN);
 			}
 		}
 

--- a/source/encoders/handlers/prores_aw_handler.cpp
+++ b/source/encoders/handlers/prores_aw_handler.cpp
@@ -60,6 +60,11 @@ void prores_aw_handler::get_defaults(obs_data_t* settings, const AVCodec*, AVCod
 	obs_data_set_default_int(settings, P_PRORES_PROFILE, 0);
 }
 
+bool encoder::ffmpeg::handler::prores_aw_handler::has_pixel_format_support(ffmpeg_factory* instance)
+{
+	return false;
+}
+
 inline const char* profile_to_name(const AVProfile* ptr)
 {
 	switch (static_cast<encoder::codec::prores::profile>(ptr->profile)) {

--- a/source/encoders/handlers/prores_aw_handler.hpp
+++ b/source/encoders/handlers/prores_aw_handler.hpp
@@ -34,19 +34,24 @@ namespace encoder::ffmpeg::handler {
 		public:
 		virtual ~prores_aw_handler(){};
 
-		public:
-		virtual void override_colorformat(AVPixelFormat& target_format, obs_data_t* settings, const AVCodec* codec,
-										  AVCodecContext* context) override;
-
+		public /*factory*/:
 		virtual void get_defaults(obs_data_t* settings, const AVCodec* codec, AVCodecContext* context,
 								  bool hw_encode) override;
 
+		public /*support tests*/:
+		virtual bool has_pixel_format_support(ffmpeg_factory* instance);
+
+		public /*settings*/:
 		virtual void get_properties(obs_properties_t* props, const AVCodec* codec, AVCodecContext* context,
 									bool hw_encode) override;
 
 		virtual void update(obs_data_t* settings, const AVCodec* codec, AVCodecContext* context) override;
 
 		virtual void log_options(obs_data_t* settings, const AVCodec* codec, AVCodecContext* context) override;
+
+		public /*instance*/:
+		virtual void override_colorformat(AVPixelFormat& target_format, obs_data_t* settings, const AVCodec* codec,
+										  AVCodecContext* context) override;
 
 		virtual void process_avpacket(AVPacket& packet, const AVCodec* codec, AVCodecContext* context) override;
 	};


### PR DESCRIPTION
Fixes the bug described in #159, which causes Look-Ahead and related settings to not be applied. Also upgrades the current code to a newer handler model in order to improve support models.
