### PR TITLE
gfx-shader: Fix rendering at unexpected sizes and fix performance

### DIFF
--- a/source/gfx/shader/gfx-shader.hpp
+++ b/source/gfx/shader/gfx-shader.hpp
@@ -23,6 +23,7 @@
 #include <random>
 #include "gfx/shader/gfx-shader-param.hpp"
 #include "obs/gs/gs-effect.hpp"
+#include "obs/gs/gs-rendertarget.hpp"
 
 namespace gfx {
 	namespace shader {
@@ -68,6 +69,10 @@ namespace gfx {
 			int32_t         _loops;
 			std::mt19937_64 _random;
 			bool            _have_current_params;
+
+			// Rendering
+			bool                              _rt_up_to_date;
+			std::shared_ptr<gs::rendertarget> _rt;
 
 			public:
 			shader(obs_source_t* self, shader_mode mode);


### PR DESCRIPTION
<!-- Hi, thank you for taking the time to submit a pull request. -->
<!-- Please make sure that you fill this out in it's entirety. -->

### Description
Fixes rendering at unexpected sizes by first rendering to a render target and then rendering the contents of that render target to the frame buffer instead. This also prevent rendering twice or more, which might cause severe FPS impact.
<!-- Describe your changes in as much detail as possible. -->
<!-- But please exclude your personal history from this. Only describe the changes -->

### Related Issues
<!-- - #0000 Name of Issue -->
<!-- - #0001 Name of Issue -->
