### PR TITLE
filter-shader, source-shader: Add new example Shaders

### DIFF
--- a/data/examples/shaders/filter/semiline.effect
+++ b/data/examples/shaders/filter/semiline.effect
@@ -1,0 +1,91 @@
+// Always provided by OBS
+uniform float4x4 ViewProj<
+	bool automatic = true;
+>;
+
+// Provided by Stream Effects
+uniform float4 Time<
+	bool automatic = true;
+>;
+uniform float4 ViewSize<
+	bool automatic = true;
+>;
+uniform texture2d InputA<
+	bool automatic = true;
+>;
+
+uniform float _pVerticalEdge<
+	string name = "Vertical Edge %";
+	string field_type = "slider";
+	float scale = 0.01;
+	float minimum = 0.0;
+	float maximum = 100.0;
+> = 50.0;
+
+uniform float _pSize<
+	string name = "Step Size (px)";
+	string field_type = "slider";
+	float scale = 1.0;
+	float minimum = 0.5;
+	float maximum = 128.0;
+	float step = 0.5;
+> = 16.0;
+
+uniform float _pBarSize<
+	string name = "Bar Size (px)";
+	string field_type = "slider";
+	float scale = 1.0;
+	float minimum = 0.5;
+	float maximum = 128.0;
+	float step = 0.5;
+> = 1.0;
+
+// ---------- Shader Code
+sampler_state def_sampler {
+	AddressU  = Wrap;
+	AddressV  = Wrap;
+	Filter    = Linear;
+};
+
+struct VertFragData {
+	float4 pos : POSITION;
+	float2 uv  : TEXCOORD0;
+};
+
+VertFragData VSDefault(VertFragData vtx) {
+	vtx.pos = mul(float4(vtx.pos.xyz, 1.0), ViewProj);
+	return vtx;
+}
+
+float4 PSDefault(VertFragData vtx) : TARGET {
+	float4 smp = InputA.Sample(def_sampler, vtx.uv);
+
+	// Increases in steps of .5 pixels.
+	if (vtx.uv.y <= _pVerticalEdge) {
+		// Y Position and Y Percent
+		float iy = _pVerticalEdge - vtx.uv.y;
+		float iyp = 1.0 - (vtx.uv.y / _pVerticalEdge);
+
+		float yc = iy * ViewSize.y;
+		float step = floor(yc / _pSize);
+
+		float yi = 1.0 - (((step + .5) * _pSize * ViewSize.w) + (1.0 - _pVerticalEdge));
+
+		float bar_size = step * _pBarSize * ViewSize.w;
+		float yd = (vtx.uv.y - yi);
+		if (abs(yd) < bar_size) {
+			return float4(0., 0., 0., 0.);
+		}
+	}
+	
+	return smp;
+}
+
+technique Draw
+{
+	pass
+	{
+		vertex_shader = VSDefault(vtx);
+		pixel_shader  = PSDefault(vtx); 
+	}
+}

--- a/data/examples/shaders/source/shadertoy-3l23Rh.effect
+++ b/data/examples/shaders/source/shadertoy-3l23Rh.effect
@@ -1,0 +1,219 @@
+// Protean clouds by nimitz (twitter: @stormoid)
+// https://www.shadertoy.com/view/3l23Rh
+// License Creative Commons Attribution-NonCommercial-ShareAlike 3.0 Unported License
+// Contact the author for other licensing options
+
+#define vec2 float2
+#define vec3 float3
+#define vec4 float4
+#define ivec2 int2
+#define ivec3 int3
+#define ivec4 int4
+#define mat2 float2x2
+#define mat3 float3x3
+#define mat4 float4x4
+#define fract frac
+#define mix lerp
+#define iTime Time.x
+#define iResolution ViewSize
+
+uniform float2 mouse<
+	string name = "Virtual Mouse Coordinates";
+	string field_type = "slider";
+	float2 minimum = {0, 0};
+	float2 maximum = {100., 100.};
+	float2 scale = {.01, .01};
+	float2 step = {.01, .01};
+> = {0., 0.};
+
+uniform float4x4 ViewProj<
+	bool automatic = true;
+>;
+
+uniform float4 Time<
+	bool automatic = true;
+>;
+
+uniform float4 ViewSize<
+	bool automatic = true;
+>;
+
+int2 iMouse() {
+	return int2(mouse.x * ViewSize.x, mouse.y * ViewSize.y);
+}
+
+/*
+	Technical details:
+
+	The main volume noise is generated from a deformed periodic grid, which can produce
+	a large range of noise-like patterns at very cheap evalutation cost. Allowing for multiple
+	fetches of volume gradient computation for improved lighting.
+
+	To further accelerate marching, since the volume is smooth, more than half the the density
+	information isn't used to rendering or shading but only as an underlying volume	distance to 
+	determine dynamic step size, by carefully selecting an equation	(polynomial for speed) to 
+	step as a function of overall density (not necessarialy rendered) the visual results can be 
+	the	same as a naive implementation with ~40% increase in rendering performance.
+
+	Since the dynamic marching step size is even less uniform due to steps not being rendered at all
+	the fog is evaluated as the difference of the fog integral at each rendered step.
+
+*/
+
+mat2 rot(in float a) {
+	float c = cos(a), s = sin(a);
+	return mat2(c,-s,s,c);
+}
+
+float mag2(vec2 p) {
+	return dot(p,p);
+}
+
+float linstep(in float mn, in float mx, in float x) {
+	return clamp((x - mn)/(mx - mn), 0., 1.);
+}
+
+// ToDo: obs parser doesn't like static - ensure that these move into functions
+//float prm1;
+//vec2 bsMo;
+
+vec2 disp(float t) {
+	return vec2(sin(t*0.22)*1., cos(t*0.175)*1.) * 2.;
+}
+
+vec2 map(vec3 p, inout float prm1, inout vec2 bsMo) {
+	const mat3 m3 = mat3(0.33338, 0.56034, -0.71817, -0.87887, 0.32651, -0.15323, 0.15162, 0.69596, 0.61339)*1.93;
+
+	vec3 p2 = p;
+	p2.xy -= disp(p.z).xy;
+	p.xy = mul(p.xy, rot(sin(p.z+iTime)*(0.1 + prm1*0.05) + iTime*0.09));
+	float cl = mag2(p2.xy);
+	float d = 0.;
+	p *= .61;
+	float z = 1.;
+	float trk = 1.;
+	float dspAmp = 0.1 + prm1*0.2;
+	for(int i = 0; i < 5; i++) {
+		p += sin(p.zxy*0.75*trk + iTime*trk*.8)*dspAmp;
+		d -= abs(dot(cos(p), sin(p.yzx))*z);
+		z *= 0.57;
+		trk *= 1.4;
+		p = mul(p, m3);
+	}
+	d = abs(d + prm1*3.)+ prm1*.3 - 2.5 + bsMo.y;
+	return vec2(d + cl*.2 + 0.25, cl);
+}
+
+vec4 render( in vec3 ro, in vec3 rd, float time, inout float prm1, inout vec2 bsMo) {
+	vec4 rez = vec4(0, 0, 0, 0);
+	const float ldst = 8.;
+	float2 dispt = disp(time + ldst) * 0.5;
+	vec3 lpos = vec3(dispt.x, dispt.y, time + ldst);
+	float t = 1.5;
+	float fogT = 0.;
+	for(int i=0; i<130; i++) {
+		if(rez.a > 0.99)break;
+
+		vec3 pos = ro + t*rd;
+		vec2 mpv = map(pos, prm1, bsMo);
+		float den = clamp(mpv.x-0.3,0.,1.)*1.12;
+		float dn = clamp((mpv.x + 2.),0.,3.);
+		
+		vec4 col = vec4(0, 0, 0, 0);
+		if (mpv.x > 0.6) {		
+			col = vec4(sin(vec3(5.,0.4,0.2) + mpv.y*0.1 +sin(pos.z*0.4)*0.5 + 1.8)*0.5 + 0.5,0.08);
+			col *= den*den*den;
+			col.rgb *= linstep(4.,-2.5, mpv.x)*2.3;
+			float dif =  clamp((den - map(pos+.8, prm1, bsMo).x)/9., 0.001, 1. );
+			dif += clamp((den - map(pos+.35, prm1, bsMo).x)/2.5, 0.001, 1. );
+			col.xyz *= den*(vec3(0.005,.045,.075) + 1.5*vec3(0.033,0.07,0.03)*dif);
+		}
+		
+		float fogC = exp(t*0.2 - 2.2);
+		col.rgba += vec4(0.06,0.11,0.11, 0.1)*clamp(fogC-fogT, 0., 1.);
+		fogT = fogC;
+		rez = rez + col*(1. - rez.a);
+		t += clamp(0.5 - dn*dn*.05, 0.09, 0.3);
+	}
+	return clamp(rez, 0.0, 1.0);
+}
+
+float getsat(vec3 c) {
+	float mi = min(min(c.x, c.y), c.z);
+	float ma = max(max(c.x, c.y), c.z);
+	return (ma - mi)/(ma+ 1e-7);
+	return 0;
+}
+
+//from my "Will it blend" shader (https://www.shadertoy.com/view/lsdGzN)
+vec3 iLerp(in vec3 a, in vec3 b, in float x) {
+	vec3 ic = mix(a, b, x) + vec3(1e-6,0.,0.);
+	float sd = abs(getsat(ic) - mix(getsat(a), getsat(b), x));
+	vec3 dir = normalize(vec3(2.*ic.x - ic.y - ic.z, 2.*ic.y - ic.x - ic.z, 2.*ic.z - ic.y - ic.x));
+	float lgt = dot(vec3(1.0, 1.0, 1.0), ic);
+	float ff = dot(dir, normalize(ic));
+	ic += 1.5*dir*sd*ff*lgt;
+	return clamp(ic,0.,1.);
+}
+
+void mainImage( out vec4 fragColor, in vec2 fragCoord ) {
+	float prm1 = 0.;
+	vec2 bsMo = {0., 0.};
+
+	vec2 q = fragCoord.xy/iResolution.xy;
+	vec2 p = (fragCoord.xy - 0.5*iResolution.xy)/iResolution.y;
+	bsMo = (iMouse().xy - 0.5*iResolution.xy)/iResolution.y;
+	
+	float time = iTime*3.;
+	vec3 ro = vec3(0,0,time);
+	
+	ro += vec3(sin(iTime)*0.5,sin(iTime*1.)*0.,0);
+		
+	float dspAmp = .85;
+	ro.xy += disp(ro.z)*dspAmp;
+	float tgtDst = 3.5;
+	
+	vec3 target = normalize(ro - vec3(disp(time + tgtDst)*dspAmp, time + tgtDst));
+	ro.x -= bsMo.x*2.;
+	vec3 rightdir = normalize(cross(target, vec3(0,1,0)));
+	vec3 updir = normalize(cross(rightdir, target));
+	rightdir = normalize(cross(updir, target));
+	vec3 rd = normalize((p.x*rightdir + p.y*updir)*1. - target);
+	rd.xy = mul(rd.xy, rot(-disp(time + 3.5).x*0.2 + bsMo.x));
+	prm1 = smoothstep(-0.4, 0.4,sin(iTime*0.3));
+	vec4 scn = render(ro, rd, time, prm1, bsMo);
+
+	vec3 col = scn.rgb;
+	col = iLerp(col.bgr, col.rgb, clamp(1.-prm1,0.05,1.));
+
+	col = pow(col, vec3(.55,0.65,0.6))*vec3(1.,.97,.9);
+
+	col *= pow( 16.0*q.x*q.y*(1.0-q.x)*(1.0-q.y), 0.12)*0.7+0.3; //Vign
+	
+	fragColor = vec4( col, 1.0 );
+}
+
+struct VertFragData {
+	float4 pos : POSITION;
+	float2 uv  : TEXCOORD0;
+};
+
+VertFragData VSDefault(VertFragData vtx) {
+	vtx.pos = mul(float4(vtx.pos.xyz, 1.0), ViewProj);
+	return vtx;
+}
+
+float4 PSDefault(VertFragData vtx) : TARGET {
+	float4 col = float4(1., 1., 1., 1.);
+	mainImage(col, vtx.uv * ViewSize.xy);
+	return col;
+}
+
+technique Draw 
+{
+	pass
+	{
+		vertex_shader = VSDefault(vtx);
+		pixel_shader  = PSDefault(vtx); 
+	}
+}

--- a/data/examples/shaders/source/shadertoy-3tlXWS.effect
+++ b/data/examples/shaders/source/shadertoy-3tlXWS.effect
@@ -1,0 +1,146 @@
+// https://www.shadertoy.com/view/3tlXWS
+
+// Always provided by OBS
+uniform float4x4 ViewProj<
+	bool automatic = true;
+>;
+
+// Provided by Stream Effects
+uniform float4 Time<
+	bool automatic = true;
+>;
+uniform float4 ViewSize<
+	bool automatic = true;
+>;
+
+// ---------- Shader Code
+// HLSL conformity
+#define vec2 float2
+#define vec3 float3
+#define vec4 float4
+
+#define FALLOFF_START 1.0
+#define DECAY_START 0.1
+#define DECAY 1.0
+
+#define GRIDW 0.02
+
+#define GRID_R 0.672443156957688
+#define GRID_G 0.0103298230296269
+#define GRID_B 0.246201326707835
+#define FALLOFF_GRID 0.75
+
+//#define GRID_R 0.0544802764424424
+//#define GRID_G 0.0
+//#define GRID_B 0.0761853814813079
+
+float sRGB(float x) {
+    if (x <= 0.00031308)
+        return 12.92 * x;
+    else
+        return 1.055*pow(x,(1.0 / 2.4) ) - 0.055;
+}
+
+float saw(float t) {
+ 	return t - floor(t);   
+}
+
+float tri(float t) {
+    return 2.0 * abs(t - floor(t + 0.5));
+}
+
+float grid(vec2 pix, float t) {
+    
+    float d = t + (pix.y / 30.0) + sin(pix.x * 500.0);
+    
+    float distortion = (sin(d * 400.0) + (sin(d * 600.0) / 2.0) + (sin(d * 800.0) / 3.0)) / 4.0;
+    
+    //float w = max(0.0, tri((pix.x + distortion) / 8.0) - (1.0 - GRIDW)) / GRIDW;
+    //float h = max(0.0, tri((pix.y + distortion) / 8.0) - (1.0 - GRIDW)) / GRIDW;
+    
+    float w = tri((pix.x + distortion) / 50.0);
+    float h = tri((pix.y + distortion) / 50.0);
+    
+    
+    float power = 1.0 + 0.25 * tri(pix.y / 50.0 + t / 6.0);
+    
+    float falloff = power * FALLOFF_GRID;
+    
+    float dist = min(w, h) * 25.0;
+    
+    
+    
+    //return min(power, max(w, h)
+    return min(power, power * (falloff * falloff) / (dist * dist));
+
+    
+    //return w;
+}
+
+float electron_beam(vec2 pix, float t) {
+	float iTime = Time.x;
+
+    
+    float beam_x = (cos(t * 1.0) * 250.0 + 1.0) / 2.0;
+    float beam_y = (sin(t * 10.0 / 9.0) * 200.0 + 1.0) / 2.0;
+
+    float dist = distance(pix, vec2(beam_x, beam_y));
+    
+    float power = 1.0 - (min(iTime - t, DECAY) / DECAY);
+    
+    float falloff = power * FALLOFF_START;
+    
+    return min(power, power * (falloff * falloff) / (dist * dist));
+}
+
+struct VertFragData {
+	float4 pos : POSITION;
+	float2 uv  : TEXCOORD0;
+};
+
+VertFragData VSDefault(VertFragData vtx) {
+	vtx.pos = mul(float4(vtx.pos.xyz, 1.0), ViewProj);
+	return vtx;
+}
+
+float4 PSDefault(VertFragData vtx) : TARGET {
+	float iTime = Time.x;
+
+    vec2 center = ViewSize.xy / 2.0;
+    
+    float scale = 512.0 / ViewSize.x;
+    
+    vec2 uv = (vtx.uv * ViewSize.xy - center) * scale;
+    
+    
+        
+    float beam = 0.0;
+    
+    float t = 0.0;
+    for (int i = 0; i < 100; i++) {
+        beam += electron_beam(uv, iTime - t);
+        t += 0.01;
+    }
+    
+    vec2 uv_r = uv - vec2(sin(iTime / 5.0 + uv.y / 100.0) * 2.0, sin(uv.x / 75.0 + iTime / 8.0));
+    vec2 uv_g = uv;
+    vec2 uv_b = uv + vec2(sin(iTime / 4.0 + uv.y / 100.0) * 2.0, cos(uv.x / 50.0 + iTime / 4.0));
+    
+    float grid_r = grid(uv_r, iTime) * GRID_R;
+    float grid_g = grid(uv_g, iTime - 0.1) * GRID_G;
+    float grid_b = grid(uv_b, iTime + 0.1) * GRID_B;
+    
+    vec3 grid_col = vec3(sRGB(grid_r), sRGB(grid_g), sRGB(grid_b));
+    vec3 beam_col = vec3(sRGB(beam * 0.25), sRGB(beam), sRGB(beam));
+    
+    return vec4(grid_col + beam_col, 1.0);	
+}
+
+technique Draw
+{
+	pass
+	{
+		vertex_shader = VSDefault(vtx);
+		pixel_shader  = PSDefault(vtx); 
+	}
+}

--- a/data/examples/shaders/source/shadertoy-MslGRn.effect
+++ b/data/examples/shaders/source/shadertoy-MslGRn.effect
@@ -1,0 +1,198 @@
+// https://www.shadertoy.com/view/MslGRn
+#define vec2 float2
+#define vec3 float3
+#define vec4 float4
+#define ivec2 int2
+#define ivec3 int3
+#define ivec4 int4
+#define mat3 float3x3
+#define mat4 float4x4
+#define fract frac
+#define mix lerp
+#define iTime Time.x
+#define iResolution ViewSize
+
+uniform float2 mouse<
+	string name = "Virtual Mouse Coordinates";
+	string field_type = "slider";
+	float2 minimum = {0, 0};
+	float2 maximum = {100., 100.};
+	float2 scale = {.01, .01};
+	float2 step = {.01, .01};
+> = {0., 0.};
+
+uniform float4x4 ViewProj<
+	bool automatic = true;
+>;
+
+uniform float4 Time<
+	bool automatic = true;
+>;
+
+uniform float4 ViewSize<
+	bool automatic = true;
+>;
+
+int2 iMouse() {
+	return int2(mouse.x * ViewSize.x, mouse.y * ViewSize.y);
+}
+
+#define TWO_OCTAVES
+#define THREE_OCTAVES
+#define SLICES 			50.0
+#define START_AMPLITUDE	0.01
+#define START_FREQUENCY	1.25
+#define START_DENSITY	0.0
+#define ANIMATION_SPEED 0.075
+
+float hash( float n )
+{
+	return fract(sin(n)*43758.5453123);
+}
+
+float noise( in vec3 x )
+{
+	vec3 p = floor(x);
+	vec3 f = fract(x);
+	f = f*f*(3.0-2.0*f);
+	float n = p.x + p.y*57.0 + 113.0*p.z;
+	float res = mix(mix(mix( hash(n+  0.0), hash(n+  1.0),f.x), mix( hash(n+ 57.0), hash(n+ 58.0),f.x),f.y), mix(mix( hash(n+113.0), hash(n+114.0),f.x), mix( hash(n+170.0), hash(n+171.0),f.x),f.y),f.z);
+	return res;
+}
+
+// fbm noise for 2-4 octaves including rotation per octave
+float fbm( vec3 p )
+{
+	// rotation matrix for fbm octaves
+	mat3 m = mat3( 0.00,  0.80,  0.60, -0.80,  0.36, -0.48, -0.60, -0.48,  0.64 );
+
+	float f = 0.0;
+	f += 0.5000*noise( p );
+	p = mul(p, m) * 2.02;
+	f += 0.2500*noise( p ); 
+#ifdef TWO_OCTAVES
+	return f/0.75;
+#else
+	p = mul(m, p) * 2.03;
+	f += 0.1250*noise( p );
+#ifdef THREE_OCTAVES
+	return f/0.875;
+#else
+	p = mul(m, p) * 2.01;
+	f += 0.0625*noise( p );
+	return f/0.9375;
+#endif
+#endif
+}
+
+vec3 gradient(float s)
+{
+	return vec3(0.0, max(1.0-s*2.0, 0.0), max(s>0.5?1.0-(s-0.5)*5.0:1.0, 0.0));
+}
+
+#define RADIUS 0.5
+bool intersectSphere(vec3 origin, vec3 direction, out float tmin, out float tmax)
+{
+	bool hit = false;
+	float a = dot(direction, direction);
+	float b = 2.0*dot(origin, direction);
+	float c = dot(origin, origin) - 0.5*0.5;
+	float disc = b*b - 4.0*a*c;						// discriminant
+	tmin = tmax = 0.0;
+
+	if (disc > 0.0) {
+		// Real root of disc, so intersection
+		float sdisc = sqrt(disc);
+		float t0 = (-b - sdisc)/(2.0*a);			// closest intersection distance
+		float t1 = (-b + sdisc)/(2.0*a);			// furthest intersection distance
+
+		tmax = t1;
+		if (t0 >= 0.0) 
+			tmin = t0;
+		hit = true;
+	}
+
+	return hit;
+}
+
+vec2 rt(vec2 x,float y)
+{
+	return vec2(cos(y)*x.x-sin(y)*x.y,sin(y)*x.x+cos(y)*x.y);
+}
+
+void mainImage( out vec4 fragColor, in vec2 fragCoord )
+{
+	// normalized and aspect ratio corrected pixel coordinate
+	vec2 p = (fragCoord.xy / iResolution.xy)*2.0-1.0;
+	p.x *= iResolution.x/ iResolution.y;
+
+	// camera and user input
+	vec3 oo = vec3(0, 0, 1.0-iMouse().y/iResolution.y);
+	vec3 od = normalize(vec3(p.x, p.y, -2.0));
+	vec3 o,d;	
+	o.xz = rt(oo.xz, 6.3*iMouse().x/iResolution.x);
+	o.y = oo.y;
+	d.xz = rt(od.xz, 6.3*iMouse().x/iResolution.x);
+	d.y = od.y;
+
+	// render
+	vec4 col = vec4(0, 0, 0, 1);
+	float tmin, tmax;
+	if (intersectSphere(o, d, tmin, tmax))
+	{	
+		// step thoug the sphere with max SLICES steps
+		for (float i = 0.0; i < SLICES; i+=1.0)
+		{
+			// stay within the sphere bounds
+			float t = tmin+i/SLICES;
+			if (t > tmax) 
+				break;
+			vec3 curpos = o + d*t;
+			
+			// get sphere falloff in s
+			float s = (0.5-length(curpos))*2.0;
+			s*=s;
+
+			// get turbulence in d
+			float a = START_AMPLITUDE;
+			float b = START_FREQUENCY;
+			float d = START_DENSITY;
+			for (int j = 0; j < 3; j++)
+			{
+				d += 0.5/abs((fbm(5.0*curpos*b+ANIMATION_SPEED*iTime/b)*2.0-1.0)/a);
+				b *= 2.0;
+				a /= 2.0;
+			}
+			
+			// get gradient color depending on s
+			col.rgb += gradient(s)*max(d*s,0.0);
+		}
+	}
+
+	fragColor = col;
+}
+
+struct VertFragData {
+	float4 pos : POSITION;
+	float2 uv  : TEXCOORD0;
+};
+
+VertFragData VSDefault(VertFragData vtx) {
+	vtx.pos = mul(float4(vtx.pos.xyz, 1.0), ViewProj);
+	return vtx;
+}
+
+float4 PSDefault(VertFragData vtx) : TARGET {
+	float4 col = float4(1., 1., 1., 1.);
+	mainImage(col, vtx.uv * ViewSize.xy);
+	return col;
+}
+
+technique Draw 
+{
+	pass
+	{
+		vertex_shader = VSDefault(vtx);
+		pixel_shader  = PSDefault(vtx); 
+	}
+}

--- a/data/examples/shaders/source/shadertoy-MslfRn.effect
+++ b/data/examples/shaders/source/shadertoy-MslfRn.effect
@@ -1,0 +1,199 @@
+// https://www.shadertoy.com/view/MslGRn
+#define vec2 float2
+#define vec3 float3
+#define vec4 float4
+#define ivec2 int2
+#define ivec3 int3
+#define ivec4 int4
+#define mat2 float2x2
+#define mat3 float3x3
+#define mat4 float4x4
+#define fract frac
+#define mix lerp
+#define iTime Time.x
+#define iResolution ViewSize
+
+uniform float2 mouse<
+	string name = "Virtual Mouse Coordinates";
+	string field_type = "slider";
+	float2 minimum = {0, 0};
+	float2 maximum = {100., 100.};
+	float2 scale = {.01, .01};
+	float2 step = {.01, .01};
+> = {0., 0.};
+
+uniform float4x4 ViewProj<
+	bool automatic = true;
+>;
+
+uniform float4 Time<
+	bool automatic = true;
+>;
+
+uniform float4 ViewSize<
+	bool automatic = true;
+>;
+
+int2 iMouse() {
+	return int2(mouse.x * ViewSize.x, mouse.y * ViewSize.y);
+}
+
+#define TAU 6.2831853
+struct M {
+	float d;
+	vec3 c;
+};
+void mmin(float d, vec3 c, inout M m){if (d<m.d){m.d=d;m.c=c;}}
+
+mat2 rz2(float a){
+	float c=cos(a),s=sin(a);
+	return mat2(c,-s,s,c);
+}
+
+float amod(float a,float m) {
+	return mod(a,m)-m*.5;
+}
+
+float random(float x) {
+	return fract(sin(x*13.+4375.));
+}
+
+float height(vec2 iuv) {
+	return sin(sin(iuv.x+iTime*.1)*sin(iuv.y+iTime*.1)*5.)*(pow(abs(iuv.x),2.)*.02+0.1);
+}
+
+void map(vec3 p, inout M m){
+   	m.d=max(max(p.y,.0),max(p.z-6.,0.));
+	vec2 uv=p.xz*2.;
+	uv.y+=iTime;
+	vec2 f=fract(uv)-.5;
+	float fft=mouse.x;
+	float l=fft/(abs(f.x)*abs(f.y));
+	l+=.1*fft/(abs(p.z-6.));
+	m.c=mix(vec3(0.196, 0.003, 0.149),vec3(1, 0.019, 0.384),l);
+	
+	uv=p.xz-.5;
+	vec2 iuv=floor(uv);
+	vec2 fuv=fract(uv);
+	float h=mix(
+		mix(height(iuv+vec2(0.,0.)), height(iuv+vec2(1.,0.)), fuv.x),
+		mix(height(iuv+vec2(0.,1.)), height(iuv+vec2(1.,1.)), fuv.x),
+		fuv.y)-1.;
+	float d=p.y-h;
+	d=max(d,abs(p.z-10.)-4.);
+	vec2 vuv=fuv*(1.-fuv);
+	float v=vuv.x*vuv.y;
+	l=.01*fft/v;
+	mmin(d, vec3(0.,0.,1.)*l, m);
+}
+
+float hash( float n )
+{
+	return fract(sin(n)*43758.5453123);
+}
+
+float _noise( in vec3 x )
+{
+	vec3 p = floor(x);
+	vec3 f = fract(x);
+	f = f*f*(3.0-2.0*f);
+	float n = p.x + p.y*57.0 + 113.0*p.z;
+	float res = mix(mix(mix( hash(n+  0.0), hash(n+  1.0),f.x), mix( hash(n+ 57.0), hash(n+ 58.0),f.x),f.y), mix(mix( hash(n+113.0), hash(n+114.0),f.x), mix( hash(n+170.0), hash(n+171.0),f.x),f.y),f.z);
+	return res;
+}
+
+vec3 noise(vec2 uv) {
+	uv *= 100.;
+	return vec3(_noise(vec3(uv.x, uv.y, 0.)), _noise(vec3(uv.x, uv.y, 2832)), _noise(vec3(uv.y, uv.x, -2371.)));
+	//return texture(iChannel1,uv*.1).rgb;
+}
+
+void mainImage( out vec4 fragColor, in vec2 fragCoord )
+{
+	M m;
+	m.d = 0.;
+	m.c = vec3(0, 0, 0);
+
+	vec2 uv = fragCoord.xy / iResolution.xy;
+	vec2 v=uv*(1.-uv);
+	uv-=.5;
+	uv.x*=iResolution.x/iResolution.y;
+	
+	vec2 uvn=uv*2.5;
+	vec2 iuvn=floor(uvn)+vec2(2.,0.);
+	vec2 fuvn=fract(uvn);
+	vec3 nb=mix(
+		mix(noise(iuvn+vec2(0.,0.)), noise(iuvn+vec2(1.,0.)), fuvn.x),
+		mix(noise(iuvn+vec2(0.,1.)), noise(iuvn+vec2(1.,1.)), fuvn.x),
+		fuvn.y)*.1;
+	vec3 c=(vec3(0.168, 0, 0.2)*.5+nb*3.);
+
+// Sky
+	vec2 suv=uv;
+	suv=mul(suv, rz2(iTime*.02));
+	//c*=vec3(1./(1.-smoothstep(0.9,1.,texture(iChannel1,suv).r)));
+	{
+		float ct = 1./(1.-smoothstep(0.9,1.,noise(suv).r));
+		c*=vec3(ct, ct, ct);
+	}
+
+// Sun
+	vec2 uvc=uv-vec2(.4,.2);
+	float circle=1.-smoothstep(.25,.252,length(uvc));
+	float raytime=uv.y*100.+iTime*2.;
+	float thr=-uvc.y*5.-1.;
+	float rays= step(thr,sin(raytime));
+	circle=min(circle,rays);
+	vec3 csun=mix(vec3(0.968, 0.137, 0.094),vec3(1, 0.819, 0.019),uvc.y*3.+.5);
+	c=mix(c,csun,circle);
+	
+	// Ground
+	vec3 ro=vec3(0.,2.,0.),rd=vec3(uv,1),mp=ro;
+	rd.yz=mul(rd.yz, rz2(-.2));
+	int i;
+	for(i=0; i<50; ++i){
+		map(mp, m);
+		if(m.d<.001){
+			break;
+		}
+		mp+=rd*.5*m.d;
+	}
+	if(mp.z < 14.) {
+		c=m.c;
+	}
+	
+	// Scanline thingy
+	c=max(c,0.);
+	float cren=fract(uv.y*200.+iTime*.5);
+	c+=(smoothstep(.2,.3,cren)-smoothstep(.7,.8,cren))*0.01;
+	c=pow(c,vec3(1./2.2, 1./2.2, 1./2.2));
+	c *= pow(v.x*v.y * 25.0, 0.25);
+	fragColor.rgb = c;
+	fragColor.a = 1.;
+}
+
+struct VertFragData {
+	float4 pos : POSITION;
+	float2 uv  : TEXCOORD0;
+};
+
+VertFragData VSDefault(VertFragData vtx) {
+	vtx.pos = mul(float4(vtx.pos.xyz, 1.0), ViewProj);
+	return vtx;
+}
+
+float4 PSDefault(VertFragData vtx) : TARGET {
+	float4 col = float4(1., 1., 1., 1.);
+	float2 uvx = float2(vtx.uv.x, 1.0 - vtx.uv.y) * ViewSize.xy;
+	mainImage(col, uvx);
+	return col;
+}
+
+technique Draw 
+{
+	pass
+	{
+		vertex_shader = VSDefault(vtx);
+		pixel_shader  = PSDefault(vtx); 
+	}
+}


### PR DESCRIPTION
<!-- Hi, thank you for taking the time to submit a pull request. -->
<!-- Please make sure that you fill this out in it's entirety. -->

### Description
There are not enough example shaders in StreamFX, and this aims to change that. I've converted some ShaderToy shaders into StreamFX shaders ready to use, which can also be used as a learning resource in order to figure out what actually needs to be done to convert ShaderToy to StreamFX shader.

* ![https://cdn.xaymar.com/private/2020-04-23/2020-04-23T07-59-14_obs64_BlindFatNeonblueguppy.png](https://cdn.xaymar.com/private/2020-04-23/2020-04-23T07-59-14_obs64_BlindFatNeonblueguppy.png)
* ![https://cdn.xaymar.com/private/2020-04-23/2020-04-23T07-59-29_obs64_TepidLawngreenArmadillo.png](https://cdn.xaymar.com/private/2020-04-23/2020-04-23T07-59-29_obs64_TepidLawngreenArmadillo.png)
* ![https://cdn.xaymar.com/private/2020-04-23/2020-04-23T07-59-41_obs64_PricklyTwinMastiff.png](https://cdn.xaymar.com/private/2020-04-23/2020-04-23T07-59-41_obs64_PricklyTwinMastiff.png)

Additionally a 'semiline.effect' filter shader was added, which can be used to mimic the effect seen in the StreamFX logo:

* ![https://cdn.xaymar.com/private/2020-04-23/2020-04-23T08-00-37_obs64_HeartyNavyblueAtlanticridleyturtle.png](https://cdn.xaymar.com/private/2020-04-23/2020-04-23T08-00-37_obs64_HeartyNavyblueAtlanticridleyturtle.png)

### Related Issues
<!-- - #0000 Name of Issue -->
<!-- - #0001 Name of Issue -->
