### PR TITLE
gfx-blur-dual-filtering: Implement asynchronous rendering

### DIFF
--- a/source/gfx/blur/gfx-blur-dual-filtering.hpp
+++ b/source/gfx/blur/gfx-blur-dual-filtering.hpp
@@ -88,7 +88,7 @@ namespace gfx {
 
 			std::shared_ptr<gs::texture> _input_texture;
 
-			std::vector<std::shared_ptr<gs::rendertarget>> _rendertargets;
+			std::vector<std::shared_ptr<gs::rendertarget>> _rts;
 
 			public:
 			dual_filtering();


### PR DESCRIPTION
<!-- Hi, thank you for taking the time to submit a pull request. -->
<!-- Please make sure that you fill this out in it's entirety. -->

### Description
Asynchronous rendering allows the GPU to perform work while the CPU performs other work, and is significantly faster than lockstep immediate rendering. By reusing existing render targets we can see a performance improvement of up to 500%, while still doing the same things.
<!-- Describe your changes in as much detail as possible. -->
<!-- But please exclude your personal history from this. Only describe the changes -->

### Related Issues
- #199 Investigate more Optimizations
<!-- - #0000 Name of Issue -->
<!-- - #0001 Name of Issue -->
