### PR TITLE
Shaders: Add Enumeration support, value Suffixes, fix boolean and improve performance

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -845,6 +845,9 @@ if(REQUIRE_SHADER_CODE)
 		"source/gfx/shader/gfx-shader-param-texture.hpp"
 		"source/gfx/shader/gfx-shader-param-texture.cpp"
 	)
+	list(APPEND PROJECT_DATA
+		"data/examples/shaders/feature-test.effect"
+	)
 endif()
 
 # Combine it all

--- a/data/examples/shaders/feature-test.effect
+++ b/data/examples/shaders/feature-test.effect
@@ -1,0 +1,113 @@
+// --------------------------------------------------------------------------------
+// Uniforms set by libobs
+uniform float4x4 ViewProj<
+	bool automatic = true;
+>;
+
+// --------------------------------------------------------------------------------
+// Uniforms set by StreamFX
+uniform float4 Time<
+	bool automatic = true;
+>;
+uniform float4 ViewSize<
+	bool automatic = true;
+>;
+
+// Filters, Transitions
+uniform texture2d InputA<
+	bool automatic = true;
+>;
+
+// Transitions
+uniform texture2d InputB<
+	bool automatic = true;
+>;
+uniform float TransitionTime<
+	bool automatic = true;
+>;
+
+// --------------------------------------------------------------------------------
+// Parameters
+uniform bool BoolParameter = false;
+uniform float FloatParameter<
+	string name = "Float Parameter";
+	string description = "This is a 32-bit floating point value.";
+	string field_type = "input";
+	string suffix = " %";
+	float minimum = -100.;
+	float maximum = 100.;
+	float step = .5;
+	float scale = .01;
+> = 0.;
+uniform float2 Float2Parameter<
+	string name = "Float2 Parameter";
+	string description = "This is a 32-bit floating point value.";
+	string field_type = "input";
+	string suffix = " %";
+	float2 minimum = {-100., -100.};
+	float2 maximum = {100., 100.};
+	float2 step = {.5, .5};
+	float2 scale = {.01, .01};
+> = {0., 0.};
+uniform float3 Float3Parameter = {0., 0., 0.};
+uniform float4 Float4Parameter = {0., 0., 0., 0.};
+uniform int IntParameter<
+	string name = "Enum Parameter";
+	string description = "This parameter is an enumeration";
+	string field_type = "enum";
+	// Enumeration
+	int enum = 4;
+	int enum_0 = 0;
+	string enum_0_name = "Null";
+	int enum_1 = 1;
+	string enum_1_name = "One";
+	int enum_2 = 2;
+	string enum_2_name = "Two"; 
+	int enum_3 = 4;
+	string enum_3_name = "Four";
+> = 0;
+uniform int2 Int2Parameter = {0, 0};
+uniform int3 Int3Parameter = {0, 0, 0};
+uniform int4 Int4Parameter = {0, 0, 0, 0};
+
+// --------------------------------------------------------------------------------
+// Vertex Processing
+struct VertexData {
+	float4 pos : POSITION;
+	float2 uv  : TEXCOORD0;
+};
+
+VertexData VSDefault(VertexData vtx) {
+	vtx.pos = mul(float4(vtx.pos.xyz, 1.), ViewProj);
+	return vtx;
+};
+
+// --------------------------------------------------------------------------------
+// Default Technique
+float4 PSDefault(VertexData vtx) : TARGET {
+	if (BoolParameter)
+		vtx.uv += 1.;
+	vtx.uv += FloatParameter;
+	vtx.uv += Float2Parameter;
+	vtx.uv += Float3Parameter.xy * Float3Parameter.zz;
+	vtx.uv += Float4Parameter.xy * Float4Parameter.zz;
+	
+	if (IntParameter == 1) {
+		return float4(1., 0., 0., 1.);
+	} else if (IntParameter == 2)  {
+		return float4(0., 1., 0., 1.);
+	} else if (IntParameter == 4)  {
+		return float4(0., 0., 1., 1.);
+	}
+
+	return float4(0., 0., 0., 1.);
+}
+
+technique Draw
+{
+	pass
+	{
+		vertex_shader = VSDefault(vtx);
+		pixel_shader  = PSDefault(vtx); 
+	}
+}

--- a/source/common.hpp
+++ b/source/common.hpp
@@ -36,6 +36,7 @@
 #include <memory>
 #include <stdexcept>
 #include <string>
+#include <string_view>
 #include <type_traits>
 #include <utility>
 

--- a/source/gfx/shader/gfx-shader-param-basic.cpp
+++ b/source/gfx/shader/gfx-shader-param-basic.cpp
@@ -22,14 +22,14 @@
 #include <sstream>
 #include <stdexcept>
 
-#define ANNO_FIELD_TYPE "field_type"
-#define ANNO_SUFFIX "suffix"
-#define ANNO_VALUE_MINIMUM "minimum"
-#define ANNO_VALUE_MAXIMUM "maximum"
-#define ANNO_VALUE_STEP "step"
-#define ANNO_VALUE_SCALE "scale"
-#define ANNO_ENUM_VALUES "values"
-#define ANNO_ENUM_VALUE "value"
+static const std::string_view _annotation_field_type      = "field_type";
+static const std::string_view _annotation_suffix          = "suffix";
+static const std::string_view _annotation_minimum         = "minimum";
+static const std::string_view _annotation_maximum         = "maximum";
+static const std::string_view _annotation_step            = "step";
+static const std::string_view _annotation_scale           = "scale";
+static const std::string_view _annotation_enum_entry      = "enum_%zu";
+static const std::string_view _annotation_enum_entry_name = "enum_%zu_name";
 
 inline bool get_annotation_string(gs::effect_parameter param, std::string anno_name, std::string& out)
 {
@@ -98,45 +98,55 @@ gfx::shader::basic_parameter::basic_parameter(gs::effect_parameter param, std::s
 		for (std::size_t idx = 0; idx < get_size(); idx++) {
 			snprintf(string_buffer, sizeof(string_buffer), "[%d]", static_cast<int32_t>(idx));
 			_names[idx] = std::string(string_buffer, string_buffer + strnlen(string_buffer, sizeof(string_buffer)));
-			snprintf(string_buffer, sizeof(string_buffer), "%s[%d]", get_key().c_str(), static_cast<int32_t>(idx));
+			snprintf(string_buffer, sizeof(string_buffer), "%s[%d]", get_key().data(), static_cast<int32_t>(idx));
 			_keys[idx] = std::string(string_buffer, string_buffer + strnlen(string_buffer, sizeof(string_buffer)));
 		}
 	}
 
 	// Detect Field Types
-	if (auto anno = get_parameter().get_annotation(ANNO_FIELD_TYPE); anno) {
+	if (auto anno = get_parameter().get_annotation(_annotation_field_type); anno) {
 		_field_type = get_field_type_from_string(anno.get_default_string());
 	}
 
 	// Read Suffix Data
-	if (auto anno = get_parameter().get_annotation(ANNO_SUFFIX); anno) {
+	if (auto anno = get_parameter().get_annotation(_annotation_suffix); anno) {
 		if (anno.get_type() == gs::effect_parameter::type::String)
 			_suffix = anno.get_default_string();
 	}
 
 	// Read Enumeration Data if Enumeration
-	if (get_field_type() == basic_field_type::Enum) {
-		if (auto anno = get_parameter().get_annotation(ANNO_ENUM_VALUES);
-			anno && (anno.get_type() == gs::effect_parameter::type::Integer)) {
-			_values.resize(static_cast<size_t>(std::max(anno.get_default_int(), 0)));
-			for (std::size_t idx = 0; idx < _values.size(); idx++) {
-				auto& entry = _values[idx];
-				snprintf(string_buffer, sizeof(string_buffer), "_%zu", idx);
-				std::string key =
-					std::string(string_buffer, string_buffer + strnlen(string_buffer, sizeof(string_buffer)));
-				if (auto annoe = anno.get_annotation(key);
-					annoe && (annoe.get_type() == gs::effect_parameter::type::String)) {
-					entry.name = annoe.get_default_string();
-					if (auto annoev = annoe.get_annotation(ANNO_ENUM_VALUE); annoev) {
-						load_parameter_data(annoev, entry.data);
-					}
-				} else {
-					LOG_WARNING("[%s] Parameter enumeration entry '%s' is of invalid type, must be string.",
-								get_name().c_str(), string_buffer);
-				}
+	if (field_type() == basic_field_type::Enum) {
+		for (std::size_t idx = 0; idx < std::numeric_limits<std::size_t>::max(); idx++) {
+			// Build key.
+			std::string key_name;
+			std::string key_value;
+			{
+				snprintf(string_buffer, sizeof(string_buffer), _annotation_enum_entry.data(), idx);
+				key_value = std::string(string_buffer);
+				snprintf(string_buffer, sizeof(string_buffer), _annotation_enum_entry_name.data(), idx);
+				key_name = std::string(string_buffer);
 			}
-		} else {
-			LOG_WARNING("[%s] Enumeration is missing entries.", get_name().c_str());
+
+			// Value must be given, name is optional.
+			if (auto eanno = get_parameter().get_annotation(key_value);
+				eanno && (get_type_from_effect_type(eanno.get_type()) == get_type())) {
+				basic_enum_data entry;
+
+				load_parameter_data(eanno, entry.data);
+				if (auto nanno = get_parameter().get_annotation(key_name);
+					nanno && (nanno.get_type() == gs::effect_parameter::type::String)) {
+					entry.name = nanno.get_default_string();
+				} else {
+					entry.name = "Unnamed Entry";
+				}
+
+				_values.push_back(entry);
+			} else {
+				break;
+			}
+		}
+
+		if (_values.size() == 0) {
 			_field_type = basic_field_type::Input;
 		}
 	}
@@ -149,30 +159,6 @@ void gfx::shader::basic_parameter::load_parameter_data(gs::effect_parameter para
 	parameter.get_default_value(&data.i32, 1);
 }
 
-gfx::shader::basic_field_type gfx::shader::basic_parameter::get_field_type()
-{
-	return _field_type;
-}
-
-const std::string& gfx::shader::basic_parameter::get_suffix()
-{
-	return _suffix;
-}
-
-const std::string& gfx::shader::basic_parameter::get_keys(std::size_t idx)
-{
-	if (idx >= get_size())
-		throw std::out_of_range("Index out of range.");
-	return _keys[idx];
-}
-
-const std::string& gfx::shader::basic_parameter::get_names(std::size_t idx)
-{
-	if (idx >= get_size())
-		throw std::out_of_range("Index out of range.");
-	return _names[idx];
-}
-
 gfx::shader::bool_parameter::bool_parameter(gs::effect_parameter param, std::string prefix)
 	: basic_parameter(param, prefix)
 {
@@ -181,7 +167,7 @@ gfx::shader::bool_parameter::bool_parameter(gs::effect_parameter param, std::str
 	_step.resize(0);
 	_scale.resize(0);
 
-	_data.resize(get_size(), true);
+	_data.resize(get_size(), 1);
 }
 
 gfx::shader::bool_parameter::~bool_parameter() {}
@@ -190,7 +176,7 @@ void gfx::shader::bool_parameter::defaults(obs_data_t* settings)
 {
 	// TODO: Support for bool[]
 	if (get_size() == 1) {
-		obs_data_set_default_bool(settings, get_key().c_str(), get_parameter().get_default_bool());
+		obs_data_set_default_int(settings, get_key().data(), get_parameter().get_default_bool() ? 1 : 0);
 	}
 }
 
@@ -201,10 +187,10 @@ void gfx::shader::bool_parameter::properties(obs_properties_t* props, obs_data_t
 
 	// TODO: Support for bool[]
 	if (get_size() == 1) {
-		auto p = obs_properties_add_list(props, get_key().c_str(), get_name().c_str(), OBS_COMBO_TYPE_LIST,
+		auto p = obs_properties_add_list(props, get_key().data(), get_name().data(), OBS_COMBO_TYPE_LIST,
 										 OBS_COMBO_FORMAT_INT);
 		if (has_description())
-			obs_property_set_long_description(p, get_description().c_str());
+			obs_property_set_long_description(p, get_description().data());
 		obs_property_list_add_int(p, D_TRANSLATE(S_STATE_DISABLED), 0);
 		obs_property_list_add_int(p, D_TRANSLATE(S_STATE_ENABLED), 1);
 	}
@@ -217,13 +203,13 @@ void gfx::shader::bool_parameter::update(obs_data_t* settings)
 
 	// TODO: Support for bool[]
 	if (get_size() == 1) {
-		_data[0] = static_cast<bool>(obs_data_get_int(settings, get_key().c_str()));
+		_data[0] = obs_data_get_int(settings, get_key().data());
 	}
 }
 
 void gfx::shader::bool_parameter::assign()
 {
-	get_parameter().set_value(_data.data(), sizeof(std::uint8_t));
+	get_parameter().set_value(_data.data(), _data.size());
 }
 
 gfx::shader::float_parameter::float_parameter(gs::effect_parameter param, std::string prefix)
@@ -240,22 +226,22 @@ gfx::shader::float_parameter::float_parameter(gs::effect_parameter param, std::s
 	}
 
 	// Load Limits
-	if (auto anno = get_parameter().get_annotation(ANNO_VALUE_MINIMUM); anno) {
+	if (auto anno = get_parameter().get_annotation(_annotation_minimum); anno) {
 		if (anno.get_type() == get_parameter().get_type()) {
 			anno.get_default_value(_min.data(), get_size());
 		}
 	}
-	if (auto anno = get_parameter().get_annotation(ANNO_VALUE_MAXIMUM); anno) {
+	if (auto anno = get_parameter().get_annotation(_annotation_maximum); anno) {
 		if (anno.get_type() == get_parameter().get_type()) {
 			anno.get_default_value(_max.data(), get_size());
 		}
 	}
-	if (auto anno = get_parameter().get_annotation(ANNO_VALUE_STEP); anno) {
+	if (auto anno = get_parameter().get_annotation(_annotation_step); anno) {
 		if (anno.get_type() == get_parameter().get_type()) {
 			anno.get_default_value(_step.data(), get_size());
 		}
 	}
-	if (auto anno = get_parameter().get_annotation(ANNO_VALUE_SCALE); anno) {
+	if (auto anno = get_parameter().get_annotation(_annotation_scale); anno) {
 		if (anno.get_type() == get_parameter().get_type()) {
 			anno.get_default_value(_scale.data(), get_size());
 		}
@@ -271,19 +257,18 @@ void gfx::shader::float_parameter::defaults(obs_data_t* settings)
 	get_parameter().get_default_value(defaults.data(), get_size());
 
 	for (std::size_t idx = 0; idx < get_size(); idx++) {
-		obs_data_set_default_double(settings, get_keys(idx).c_str(), static_cast<double_t>(defaults[idx]));
+		obs_data_set_default_double(settings, key_at(idx).data(), static_cast<double_t>(defaults[idx]));
 	}
 }
 
 static inline obs_property_t* build_float_property(gfx::shader::basic_field_type ft, obs_properties_t* props,
 												   const char* key, const char* name, float_t min, float_t max,
-												   float_t step, std::vector<gfx::shader::basic_enum_data> edata)
+												   float_t step, std::list<gfx::shader::basic_enum_data> edata)
 {
 	switch (ft) {
 	case gfx::shader::basic_field_type::Enum: {
 		auto p = obs_properties_add_list(props, key, name, OBS_COMBO_TYPE_LIST, OBS_COMBO_FORMAT_FLOAT);
-		for (std::size_t idx = 0; idx < edata.size(); idx++) {
-			auto& el = edata.at(idx);
+		for (auto& el : edata) {
 			obs_property_list_add_float(p, el.name.c_str(), el.data.f32);
 		}
 		return p;
@@ -301,31 +286,28 @@ void gfx::shader::float_parameter::properties(obs_properties_t* props, obs_data_
 	if (!is_visible())
 		return;
 
-	if (get_size() == 1) {
-		auto p = build_float_property(_field_type, props, _keys[0].c_str(), _names[0].c_str(), _min[0].f32, _max[0].f32,
-									  _step[0].f32, _values);
+	obs_properties_t* pr = props;
+	if (get_size() > 1) {
+		pr     = obs_properties_create();
+		auto p = obs_properties_add_group(props, get_key().data(), has_name() ? get_name().data() : get_key().data(),
+										  OBS_GROUP_NORMAL, pr);
 		if (has_description())
-			obs_property_set_long_description(p, get_description().c_str());
-	} else {
-		auto grp = obs_properties_create();
-		auto p = obs_properties_add_group(props, get_key().c_str(), has_name() ? get_name().c_str() : get_key().c_str(),
-										  OBS_GROUP_NORMAL, grp);
-		if (has_description())
-			obs_property_set_long_description(p, get_description().c_str());
+			obs_property_set_long_description(p, get_description().data());
+	}
 
-		for (std::size_t idx = 0; idx < get_size(); idx++) {
-			p = build_float_property(_field_type, grp, _keys[idx].c_str(), _names[idx].c_str(), _min[idx].f32,
-									 _max[idx].f32, _step[idx].f32, _values);
-			if (has_description())
-				obs_property_set_long_description(p, get_description().c_str());
-		}
+	for (std::size_t idx = 0; idx < get_size(); idx++) {
+		auto p = build_float_property(field_type(), pr, key_at(idx).data(), name_at(idx).data(), _min[idx].f32,
+									  _max[idx].f32, _step[idx].f32, _values);
+		if (has_description())
+			obs_property_set_long_description(p, get_description().data());
+		obs_property_float_set_suffix(p, suffix().data());
 	}
 }
 
 void gfx::shader::float_parameter::update(obs_data_t* settings)
 {
 	for (std::size_t idx = 0; idx < get_size(); idx++) {
-		_data[idx].f32 = static_cast<float_t>(obs_data_get_double(settings, _keys[idx].c_str())) * _scale[idx].f32;
+		_data[idx].f32 = static_cast<float_t>(obs_data_get_double(settings, key_at(idx).data())) * _scale[idx].f32;
 	}
 }
 
@@ -338,13 +320,12 @@ void gfx::shader::float_parameter::assign()
 }
 static inline obs_property_t* build_int_property(gfx::shader::basic_field_type ft, obs_properties_t* props,
 												 const char* key, const char* name, int32_t min, int32_t max,
-												 int32_t step, std::vector<gfx::shader::basic_enum_data> edata)
+												 int32_t step, std::list<gfx::shader::basic_enum_data> edata)
 {
 	switch (ft) {
 	case gfx::shader::basic_field_type::Enum: {
 		auto p = obs_properties_add_list(props, key, name, OBS_COMBO_TYPE_LIST, OBS_COMBO_FORMAT_INT);
-		for (std::size_t idx = 0; idx < edata.size(); idx++) {
-			auto& el = edata.at(idx);
+		for (auto& el : edata) {
 			obs_property_list_add_int(p, el.name.c_str(), el.data.i32);
 		}
 		return p;
@@ -371,22 +352,22 @@ gfx::shader::int_parameter::int_parameter(gs::effect_parameter param, std::strin
 	}
 
 	// Load Limits
-	if (auto anno = get_parameter().get_annotation(ANNO_VALUE_MINIMUM); anno) {
+	if (auto anno = get_parameter().get_annotation(_annotation_minimum); anno) {
 		if (anno.get_type() == get_parameter().get_type()) {
 			anno.get_default_value(_min.data(), get_size());
 		}
 	}
-	if (auto anno = get_parameter().get_annotation(ANNO_VALUE_MAXIMUM); anno) {
+	if (auto anno = get_parameter().get_annotation(_annotation_maximum); anno) {
 		if (anno.get_type() == get_parameter().get_type()) {
 			anno.get_default_value(_max.data(), get_size());
 		}
 	}
-	if (auto anno = get_parameter().get_annotation(ANNO_VALUE_STEP); anno) {
+	if (auto anno = get_parameter().get_annotation(_annotation_step); anno) {
 		if (anno.get_type() == get_parameter().get_type()) {
 			anno.get_default_value(_step.data(), get_size());
 		}
 	}
-	if (auto anno = get_parameter().get_annotation(ANNO_VALUE_SCALE); anno) {
+	if (auto anno = get_parameter().get_annotation(_annotation_scale); anno) {
 		if (anno.get_type() == get_parameter().get_type()) {
 			anno.get_default_value(_scale.data(), get_size());
 		}
@@ -401,7 +382,7 @@ void gfx::shader::int_parameter::defaults(obs_data_t* settings)
 	defaults.resize(get_size());
 	get_parameter().get_default_value(defaults.data(), get_size());
 	for (std::size_t idx = 0; idx < get_size(); idx++) {
-		obs_data_set_default_int(settings, get_keys(idx).c_str(), defaults[idx]);
+		obs_data_set_default_int(settings, key_at(idx).data(), defaults[idx]);
 	}
 }
 
@@ -410,31 +391,28 @@ void gfx::shader::int_parameter::properties(obs_properties_t* props, obs_data_t*
 	if (!is_visible())
 		return;
 
-	if (get_size() == 1) {
-		auto p = build_int_property(_field_type, props, _keys[0].c_str(), _names[0].c_str(), _min[0].i32, _max[0].i32,
-									_step[0].i32, _values);
+	obs_properties_t* pr = props;
+	if (get_size() > 1) {
+		pr     = obs_properties_create();
+		auto p = obs_properties_add_group(props, get_key().data(), has_name() ? get_name().data() : get_key().data(),
+										  OBS_GROUP_NORMAL, pr);
 		if (has_description())
-			obs_property_set_long_description(p, get_description().c_str());
-	} else {
-		auto grp = obs_properties_create();
-		auto p = obs_properties_add_group(props, get_key().c_str(), has_name() ? get_name().c_str() : get_key().c_str(),
-										  OBS_GROUP_NORMAL, grp);
-		if (has_description())
-			obs_property_set_long_description(p, get_description().c_str());
+			obs_property_set_long_description(p, get_description().data());
+	}
 
-		for (std::size_t idx = 0; idx < get_size(); idx++) {
-			p = build_int_property(_field_type, grp, _keys[idx].c_str(), _names[idx].c_str(), _min[idx].i32,
-								   _max[idx].i32, _step[idx].i32, _values);
-			if (has_description())
-				obs_property_set_long_description(p, get_description().c_str());
-		}
+	for (std::size_t idx = 0; idx < get_size(); idx++) {
+		auto p = build_int_property(field_type(), pr, key_at(idx).data(), name_at(idx).data(), _min[idx].i32,
+									_max[idx].i32, _step[idx].i32, _values);
+		if (has_description())
+			obs_property_set_long_description(p, get_description().data());
+		obs_property_int_set_suffix(p, suffix().data());
 	}
 }
 
 void gfx::shader::int_parameter::update(obs_data_t* settings)
 {
 	for (std::size_t idx = 0; idx < get_size(); idx++) {
-		_data[idx].i32 = static_cast<int32_t>(obs_data_get_int(settings, _keys[idx].c_str()) * _scale[idx].i32);
+		_data[idx].i32 = static_cast<int32_t>(obs_data_get_int(settings, key_at(idx).data()) * _scale[idx].i32);
 	}
 }
 

--- a/source/gfx/shader/gfx-shader-param-basic.hpp
+++ b/source/gfx/shader/gfx-shader-param-basic.hpp
@@ -44,7 +44,7 @@ namespace gfx {
 			basic_data  data;
 		};
 
-		struct basic_parameter : public parameter {
+		class basic_parameter : public parameter {
 			// Descriptor
 			basic_field_type         _field_type;
 			std::string              _suffix;
@@ -59,7 +59,7 @@ namespace gfx {
 			std::vector<basic_data> _scale;
 
 			// Enumeration Information
-			std::vector<basic_enum_data> _values;
+			std::list<basic_enum_data> _values;
 
 			public:
 			basic_parameter(gs::effect_parameter param, std::string prefix);
@@ -68,18 +68,34 @@ namespace gfx {
 			virtual void load_parameter_data(gs::effect_parameter parameter, basic_data& data);
 
 			public:
-			basic_field_type get_field_type();
+			inline basic_field_type field_type()
+			{
+				return _field_type;
+			}
 
-			const std::string& get_suffix();
+			inline std::string_view suffix()
+			{
+				return _suffix;
+			}
 
-			const std::string& get_keys(std::size_t idx);
+			inline std::string_view key_at(std::size_t idx)
+			{
+				if (idx >= get_size())
+					throw std::out_of_range("Index out of range.");
+				return _keys[idx];
+			}
 
-			const std::string& get_names(std::size_t idx);
+			inline std::string_view name_at(std::size_t idx)
+			{
+				if (idx >= get_size())
+					throw std::out_of_range("Index out of range.");
+				return _names[idx];
+			}
 		};
 
 		struct bool_parameter : public basic_parameter {
 			// std::vector<bool> doesn't allow .data()
-			std::vector<std::uint8_t> _data;
+			std::vector<std::int32_t> _data;
 
 			public:
 			bool_parameter(gs::effect_parameter param, std::string prefix);

--- a/source/gfx/shader/gfx-shader-param.cpp
+++ b/source/gfx/shader/gfx-shader-param.cpp
@@ -175,61 +175,6 @@ void gfx::shader::parameter::update(obs_data_t* settings) {}
 
 void gfx::shader::parameter::assign() {}
 
-gs::effect_parameter gfx::shader::parameter::get_parameter()
-{
-	return _param;
-}
-
-gfx::shader::parameter_type gfx::shader::parameter::get_type()
-{
-	return _type;
-}
-
-std::size_t gfx::shader::parameter::get_size()
-{
-	return _size;
-}
-
-int32_t gfx::shader::parameter::get_order()
-{
-	return _order;
-}
-
-const std::string& gfx::shader::parameter::get_key()
-{
-	return _key;
-}
-
-bool gfx::shader::parameter::is_visible()
-{
-	return _visible && !is_automatic();
-}
-
-bool gfx::shader::parameter::is_automatic()
-{
-	return _automatic;
-}
-
-bool gfx::shader::parameter::has_name()
-{
-	return _name.length() > 0;
-}
-
-const std::string& gfx::shader::parameter::get_name()
-{
-	return _name;
-}
-
-bool gfx::shader::parameter::has_description()
-{
-	return _description.length() > 0;
-}
-
-const std::string& gfx::shader::parameter::get_description()
-{
-	return _description;
-}
-
 std::shared_ptr<gfx::shader::parameter> gfx::shader::parameter::make_parameter(gs::effect_parameter param,
 																			   std::string          prefix)
 {

--- a/source/gfx/shader/gfx-shader-param.hpp
+++ b/source/gfx/shader/gfx-shader-param.hpp
@@ -81,27 +81,60 @@ namespace gfx {
 			virtual void assign();
 
 			public:
-			gs::effect_parameter get_parameter();
+			inline gs::effect_parameter get_parameter()
+			{
+				return _param;
+			}
 
-			parameter_type get_type();
+			inline parameter_type get_type()
+			{
+				return _type;
+			}
 
-			std::size_t get_size();
+			inline std::size_t get_size()
+			{
+				return _size;
+			}
 
-			int32_t get_order();
+			inline int32_t get_order()
+			{
+				return _order;
+			}
 
-			const std::string& get_key();
+			inline std::string_view get_key()
+			{
+				return _key;
+			}
 
-			bool is_visible();
+			inline bool is_visible()
+			{
+				return _visible && !_automatic;
+			}
 
-			bool is_automatic();
+			inline bool is_automatic()
+			{
+				return _automatic;
+			}
 
-			bool has_name();
+			inline bool has_name()
+			{
+				return _name.length() > 0;
+			}
 
-			const std::string& get_name();
+			inline std::string_view get_name()
+			{
+				return _name;
+			}
 
-			bool has_description();
+			inline bool has_description()
+			{
+				return _description.length() > 0;
+			}
 
-			const std::string& get_description();
+			inline std::string_view get_description()
+			{
+				return _description;
+			}
 
 			public:
 			static std::shared_ptr<parameter> make_parameter(gs::effect_parameter param, std::string prefix);

--- a/source/gfx/shader/gfx-shader.cpp
+++ b/source/gfx/shader/gfx-shader.cpp
@@ -509,9 +509,17 @@ void gfx::shader::shader::set_input_a(std::shared_ptr<gs::texture> tex)
 	if (!_shader)
 		return;
 
-	if (gs::effect_parameter el = _shader.get_parameter("InputA"); el != nullptr) {
-		if (el.get_type() == gs::effect_parameter::type::Texture) {
-			el.set_texture(tex);
+	std::string_view params[] = {
+		"InputA",
+		"image",
+		"tex_a",
+	};
+	for (auto& name : params) {
+		if (gs::effect_parameter el = _shader.get_parameter(name.data()); el != nullptr) {
+			if (el.get_type() == gs::effect_parameter::type::Texture) {
+				el.set_texture(tex);
+				break;
+			}
 		}
 	}
 }
@@ -521,9 +529,17 @@ void gfx::shader::shader::set_input_b(std::shared_ptr<gs::texture> tex)
 	if (!_shader)
 		return;
 
-	if (gs::effect_parameter el = _shader.get_parameter("InputB"); el != nullptr) {
-		if (el.get_type() == gs::effect_parameter::type::Texture) {
-			el.set_texture(tex);
+	std::string_view params[] = {
+		"InputB",
+		"image2",
+		"tex_b",
+	};
+	for (auto& name : params) {
+		if (gs::effect_parameter el = _shader.get_parameter(name.data()); el != nullptr) {
+			if (el.get_type() == gs::effect_parameter::type::Texture) {
+				el.set_texture(tex);
+				break;
+			}
 		}
 	}
 }

--- a/source/gfx/shader/gfx-shader.hpp
+++ b/source/gfx/shader/gfx-shader.hpp
@@ -38,7 +38,7 @@ namespace gfx {
 			Transition,
 		};
 
-		typedef std::map<std::string, std::shared_ptr<parameter>> shader_param_map_t;
+		typedef std::map<std::string_view, std::shared_ptr<parameter>> shader_param_map_t;
 
 		class shader {
 			obs_source_t* _self;

--- a/source/obs/gs/gs-effect-parameter.cpp
+++ b/source/obs/gs/gs-effect-parameter.cpp
@@ -112,11 +112,9 @@ try {
 	return *this;
 }
 
-std::string gs::effect_parameter::get_name()
+std::string_view gs::effect_parameter::get_name()
 {
-	const char* name_c   = get()->name;
-	std::size_t name_len = strnlen(name_c, 256);
-	return name_c ? std::string(name_c, name_c + name_len) : std::string();
+	return std::string_view{get()->name};
 }
 
 gs::effect_parameter::type gs::effect_parameter::get_type()
@@ -166,11 +164,11 @@ gs::effect_parameter gs::effect_parameter::get_annotation(std::size_t idx)
 	return effect_parameter(get()->annotations.array + idx, this);
 }
 
-gs::effect_parameter gs::effect_parameter::get_annotation(std::string name)
+gs::effect_parameter gs::effect_parameter::get_annotation(const std::string_view name)
 {
 	for (std::size_t idx = 0; idx < get()->annotations.num; idx++) {
 		auto ptr = get()->annotations.array + idx;
-		if (strcmp(ptr->name, name.c_str()) == 0) {
+		if (name == std::string_view{ptr->name}) {
 			return gs::effect_parameter(ptr, this);
 		}
 	}
@@ -178,7 +176,7 @@ gs::effect_parameter gs::effect_parameter::get_annotation(std::string name)
 	return nullptr;
 }
 
-bool gs::effect_parameter::has_annotation(std::string name)
+bool gs::effect_parameter::has_annotation(const std::string_view name)
 {
 	auto eprm = get_annotation(name);
 	if (eprm)
@@ -186,7 +184,7 @@ bool gs::effect_parameter::has_annotation(std::string name)
 	return false;
 }
 
-bool gs::effect_parameter::has_annotation(std::string name, effect_parameter::type type)
+bool gs::effect_parameter::has_annotation(const std::string_view name, effect_parameter::type type)
 {
 	auto eprm = get_annotation(name);
 	if (eprm)

--- a/source/obs/gs/gs-effect-parameter.hpp
+++ b/source/obs/gs/gs-effect-parameter.hpp
@@ -61,15 +61,15 @@ namespace gs {
 		effect_parameter(effect_parameter&& rhs) noexcept;
 		effect_parameter& operator=(effect_parameter&& rhs) noexcept;
 
-		std::string get_name();
+		std::string_view get_name();
 
 		type get_type();
 
 		std::size_t      count_annotations();
 		effect_parameter get_annotation(std::size_t idx);
-		effect_parameter get_annotation(std::string name);
-		bool             has_annotation(std::string name);
-		bool             has_annotation(std::string name, effect_parameter::type type);
+		effect_parameter get_annotation(const std::string_view name);
+		bool             has_annotation(const std::string_view name);
+		bool             has_annotation(const std::string_view name, effect_parameter::type type);
 
 		public /* Memory API */:
 		std::size_t get_default_value_size_in_bytes()

--- a/source/transitions/transition-shader.cpp
+++ b/source/transitions/transition-shader.cpp
@@ -86,7 +86,6 @@ void shader_instance::video_render(gs_effect_t* effect)
 	gs::debug_marker gdmp{gs::debug_color_source, "Shader Transition '%s'", obs_source_get_name(_self)};
 #endif
 
-	_fx->prepare_render();
 	obs_transition_video_render(
 		_self, [](void* data, gs_texture_t* a, gs_texture_t* b, float t, std::uint32_t cx, std::uint32_t cy) {
 			reinterpret_cast<shader_instance*>(data)->transition_render(a, b, t, cx, cy);
@@ -99,6 +98,7 @@ void shader_instance::transition_render(gs_texture_t* a, gs_texture_t* b, float_
 	_fx->set_input_b(std::make_shared<::gs::texture>(b, false));
 	_fx->set_transition_time(t);
 	_fx->set_transition_size(cx, cy);
+	_fx->prepare_render();
 	_fx->render();
 }
 


### PR DESCRIPTION
<!-- Hi, thank you for taking the time to submit a pull request. -->
<!-- Please make sure that you fill this out in it's entirety. -->

### Description
This is a combined PR of multiple smaller changes.

* Adds enumeration support for float and int types for Shaders. Enumerations allow you to give users the option to select features or options for features.
* Adds support for suffixes to be defined and shown to the user.
* Replaces the use of std::string with std::string_view, which is much more optimal for our use case as we don't need modifyable strings. This has a larger impact on less memory bandwidth systems.
* Fixes support for bool paramters.
* Further optimizations with inlining

### Related Issues
- #0005 Fully implement gfx::shader
<!-- - #0001 Name of Issue -->
