### PR TITLE
encoders/ffmpeg: Assume source pixel format for empty support lists

### DIFF
--- a/source/encoders/ffmpeg-encoder.cpp
+++ b/source/encoders/ffmpeg-encoder.cpp
@@ -565,7 +565,11 @@ void ffmpeg_instance::initialize_sw(obs_data_t* settings)
 		AVPixelFormat _pixfmt_target = static_cast<AVPixelFormat>(obs_data_get_int(settings, KEY_FFMPEG_COLORFORMAT));
 		if (_pixfmt_target == AV_PIX_FMT_NONE) {
 			// Find the best conversion format.
-			_pixfmt_target = ::ffmpeg::tools::get_least_lossy_format(_codec->pix_fmts, _pixfmt_source);
+			if (_codec->pix_fmts) {
+				_pixfmt_target = ::ffmpeg::tools::get_least_lossy_format(_codec->pix_fmts, _pixfmt_source);
+			} else { // If there are no supported formats, just pass in the current one.
+				_pixfmt_target = _pixfmt_source;
+			}
 
 			if (_handler) // Allow Handler to override the automatic color format for sanity reasons.
 				_handler->override_colorformat(_pixfmt_target, settings, _codec, _context);


### PR DESCRIPTION
<!-- Hi, thank you for taking the time to submit a pull request. -->
<!-- Please make sure that you fill this out in it's entirety. -->

### Description
When the pixel format support list is empty, just assume that we can pass in the source format.
<!-- Describe your changes in as much detail as possible. -->
<!-- But please exclude your personal history from this. Only describe the changes -->

### Related Issues
- Fixes #223 Crash in get_least_lossy_format
<!-- - #0001 Name of Issue -->
