### PR TITLE
source/mirror: Fix rare out-of-order lock on source

### DIFF
--- a/source/sources/source-mirror.cpp
+++ b/source/sources/source-mirror.cpp
@@ -126,13 +126,7 @@ void mirror_instance::save(obs_data_t* data)
 	}
 }
 
-void mirror_instance::video_tick(float_t time)
-{
-	if (_source) {
-		_source_size.first  = obs_source_get_width(_source.get());
-		_source_size.second = obs_source_get_height(_source.get());
-	}
-}
+void mirror_instance::video_tick(float_t time) {}
 
 void mirror_instance::video_render(gs_effect_t* effect)
 {
@@ -145,6 +139,9 @@ void mirror_instance::video_render(gs_effect_t* effect)
 	gs::debug_marker gdmp{gs::debug_color_source, "Source Mirror '%s' for '%s'", obs_source_get_name(_self),
 						  obs_source_get_name(_source.get())};
 #endif
+
+	_source_size.first  = obs_source_get_width(_source.get());
+	_source_size.second = obs_source_get_height(_source.get());
 
 	obs_source_video_render(_source.get());
 }


### PR DESCRIPTION
<!-- Hi, thank you for taking the time to submit a pull request. -->
<!-- Please make sure that you fill this out in it's entirety. -->

### Description
Occasionally, mostly due to other sources rebuilding their UI, an out-of-order lock freeze can be observed with Source Mirror. This is unwanted, so we need to move the freezing logic into a place where freezing shouldn't happen.
<!-- Describe your changes in as much detail as possible. -->
<!-- But please exclude your personal history from this. Only describe the changes -->

### Related Issues
- Fixes #228
- Actually fixes #61
