### PR TITLE
Fix Shader filters not rendering in the correct size

### DIFF
--- a/source/filters/filter-shader.cpp
+++ b/source/filters/filter-shader.cpp
@@ -95,9 +95,9 @@ void shader_instance::video_render(gs_effect_t* effect)
 		gs::debug_marker gdm{gs::debug_color_source, "Cache"};
 #endif
 
-		auto op = _rt->render(_fx->width(), _fx->height());
+		auto op = _rt->render(_fx->base_width(), _fx->base_height());
 
-		gs_ortho(0, static_cast<float_t>(_fx->width()), 0, static_cast<float_t>(_fx->height()), -1, 1);
+		gs_ortho(0, 1, 0, 1, -1, 1);
 
 		vec4 clear_color = {0, 0, 0, 0};
 		gs_clear(GS_CLEAR_COLOR | GS_CLEAR_DEPTH, &clear_color, 0, 0);
@@ -114,7 +114,7 @@ void shader_instance::video_render(gs_effect_t* effect)
 			gs_enable_color(true, true, true, true);
 			gs_set_cull_mode(GS_NEITHER);
 
-			obs_source_process_filter_end(_self, obs_get_base_effect(OBS_EFFECT_DEFAULT), _fx->width(), _fx->height());
+			obs_source_process_filter_end(_self, obs_get_base_effect(OBS_EFFECT_DEFAULT), 1, 1);
 
 			gs_blend_state_pop();
 		} else {

--- a/source/gfx/shader/gfx-shader.cpp
+++ b/source/gfx/shader/gfx-shader.cpp
@@ -373,16 +373,16 @@ std::uint32_t gfx::shader::shader::width()
 	case shader_mode::Source:
 		switch (_width_type) {
 		case size_type::Pixel:
-			return std::clamp(static_cast<uint32_t>(_width_value), 1u, 8192u);
+			return std::clamp(static_cast<uint32_t>(_width_value), 1u, 16384u);
 		case size_type::Percent:
-			return std::clamp(static_cast<uint32_t>(_width_value * _base_width), 1u, 8192u);
+			return std::clamp(static_cast<uint32_t>(_width_value * _base_width), 1u, 16384u);
 		}
 	case shader_mode::Filter:
 		switch (_width_type) {
 		case size_type::Pixel:
-			return std::clamp(static_cast<uint32_t>(_width_value), 1u, 8192u);
+			return std::clamp(static_cast<uint32_t>(_width_value), 1u, 16384u);
 		case size_type::Percent:
-			return std::clamp(static_cast<uint32_t>(_width_value * _base_width), 1u, 8192u);
+			return std::clamp(static_cast<uint32_t>(_width_value * _base_width), 1u, 16384u);
 		}
 	default:
 		return 0;
@@ -397,20 +397,30 @@ std::uint32_t gfx::shader::shader::height()
 	case shader_mode::Source:
 		switch (_height_type) {
 		case size_type::Pixel:
-			return std::clamp(static_cast<uint32_t>(_height_value), 1u, 8192u);
+			return std::clamp(static_cast<uint32_t>(_height_value), 1u, 16384u);
 		case size_type::Percent:
-			return std::clamp(static_cast<uint32_t>(_height_value * _base_height), 1u, 8192u);
+			return std::clamp(static_cast<uint32_t>(_height_value * _base_height), 1u, 16384u);
 		}
 	case shader_mode::Filter:
 		switch (_height_type) {
 		case size_type::Pixel:
-			return std::clamp(static_cast<uint32_t>(_height_value), 1u, 8192u);
+			return std::clamp(static_cast<uint32_t>(_height_value), 1u, 16384u);
 		case size_type::Percent:
-			return std::clamp(static_cast<uint32_t>(_height_value * _base_height), 1u, 8192u);
+			return std::clamp(static_cast<uint32_t>(_height_value * _base_height), 1u, 16384u);
 		}
 	default:
 		return 0;
 	}
+}
+
+std::uint32_t gfx::shader::shader::base_width()
+{
+	return _base_width;
+}
+
+std::uint32_t gfx::shader::shader::base_height()
+{
+	return _base_height;
 }
 
 bool gfx::shader::shader::tick(float_t time)

--- a/source/gfx/shader/gfx-shader.hpp
+++ b/source/gfx/shader/gfx-shader.hpp
@@ -101,6 +101,10 @@ namespace gfx {
 
 			std::uint32_t height();
 
+			std::uint32_t base_width();
+
+			std::uint32_t base_height();
+
 			bool tick(float_t time);
 
 			void prepare_render();


### PR DESCRIPTION
<!-- Hi, thank you for taking the time to submit a pull request. -->
<!-- Please make sure that you fill this out in it's entirety. -->

### Description
Fixes a bug that causes Shader filters not using the correct internal resolution, causing their result to be blocky instead of high resolution.
<!-- Describe your changes in as much detail as possible. -->
<!-- But please exclude your personal history from this. Only describe the changes -->

### Related Issues
<!-- - #0000 Name of Issue -->
<!-- - #0001 Name of Issue -->
