### PR TITLE
sources/mirror: Retrieve source size on acquire

### DIFF
--- a/source/sources/source-mirror.cpp
+++ b/source/sources/source-mirror.cpp
@@ -173,8 +173,10 @@ try {
 	}
 
 	// Everything went well, store.
-	_source_child = std::make_shared<obs::tools::child_source>(_self, source);
-	_source       = source;
+	_source_child       = std::make_shared<obs::tools::child_source>(_self, source);
+	_source             = source;
+	_source_size.first  = obs_source_get_width(_source.get());
+	_source_size.second = obs_source_get_height(_source.get());
 
 	// Listen to the rename event to update our own settings.
 	_signal_rename = std::make_shared<obs::source_signal_handler>("rename", _source);


### PR DESCRIPTION
<!-- Hi, thank you for taking the time to submit a pull request. -->
<!-- Please make sure that you fill this out in it's entirety. -->

### Description
Fixes a bug that causes Source Mirror to initialize as an invisible source, due to OBS not calling video_render on sources with 0x0 size. Unfortunately a side effect of not being able to use the video_tick, get_width, or get_height functions to retrieve the size of a source.
<!-- Describe your changes in as much detail as possible. -->
<!-- But please exclude your personal history from this. Only describe the changes -->

### Related Issues
<!-- - #0000 Name of Issue -->
<!-- - #0001 Name of Issue -->
