### PR TITLE
encoders/ffmpeg: Add support for settings migration

### DIFF
--- a/source/encoders/encoder-ffmpeg.cpp
+++ b/source/encoders/encoder-ffmpeg.cpp
@@ -180,7 +180,11 @@ void ffmpeg_instance::get_properties(obs_properties_t* props)
 	obs_property_set_enabled(obs_properties_get(props, KEY_FFMPEG_GPU), false);
 }
 
-void ffmpeg_instance::migrate(obs_data_t* settings, std::uint64_t version) {}
+void ffmpeg_instance::migrate(obs_data_t* settings, std::uint64_t version)
+{
+	if (_handler)
+		_handler->migrate(settings, version, _codec, _context);
+}
 
 bool ffmpeg_instance::update(obs_data_t* settings)
 {

--- a/source/encoders/handlers/handler.hpp
+++ b/source/encoders/handlers/handler.hpp
@@ -60,6 +60,8 @@ namespace streamfx::encoder::ffmpeg {
 			virtual void get_properties(obs_properties_t* props, const AVCodec* codec, AVCodecContext* context,
 										bool hw_encode){};
 
+			virtual void migrate(obs_data_t* settings, std::uint64_t version, const AVCodec* codec, AVCodecContext* context){};
+
 			virtual void update(obs_data_t* settings, const AVCodec* codec, AVCodecContext* context){};
 
 			virtual void override_update(ffmpeg_instance* instance, obs_data_t* settings){};


### PR DESCRIPTION
<!-- Hi, thank you for taking the time to submit a pull request. -->
<!-- Please make sure that you fill this out in it's entirety. -->

### Description
Adds support for classic settings migration between plugin versions.
<!-- Describe your changes in as much detail as possible. -->
<!-- But please exclude your personal history from this. Only describe the changes -->

### Related Issues
<!-- - #0000 Name of Issue -->
<!-- - #0001 Name of Issue -->
