### PR TITLE
Fix fallbacks for FFmpeg encoders not working properly

### DIFF
--- a/source/encoders/encoder-ffmpeg.hpp
+++ b/source/encoders/encoder-ffmpeg.hpp
@@ -77,7 +77,7 @@ namespace streamfx::encoder::ffmpeg {
 		std::chrono::high_resolution_clock::time_point _free_frames_last_used;
 
 		public:
-		ffmpeg_instance(obs_data_t* settings, obs_encoder_t* self);
+		ffmpeg_instance(obs_data_t* settings, obs_encoder_t* self, bool is_hw);
 		virtual ~ffmpeg_instance();
 
 		public:


### PR DESCRIPTION
<!-- Hi, thank you for taking the time to submit a pull request. -->
<!-- Please make sure that you fill this out in it's entirety. -->

### Description
In 0.9.x a change was added to improve encoder stability, which broke the fallback encoders for hardware encoding, and accidentally revealed all encoders which did not have a handler implementation. Additionally the encoders were renamed from `streamfx--encoder` to `streamfx-encoder` as the previous name was a typo.
<!-- Describe your changes in as much detail as possible. -->
<!-- But please exclude your personal history from this. Only describe the changes -->

### Related Issues
- #295 Software fallback not working for NVENC.
<!-- - #0000 Name of Issue -->
<!-- - #0001 Name of Issue -->
