### PR TITLE
FFmpeg Encoder: Fix string value logging in NVENC

### DIFF
--- a/source/encoders/handlers/nvenc_h264_handler.cpp
+++ b/source/encoders/handlers/nvenc_h264_handler.cpp
@@ -133,20 +133,10 @@ void nvenc_h264_handler::log_options(obs_data_t* settings, const AVCodec* codec,
 	nvenc::log_options(settings, codec, context);
 
 	DLOG_INFO("[%s]     H.264/AVC:", codec->name);
-	::ffmpeg::tools::print_av_option_string(context, "profile", "      Profile", [](int64_t v) {
-		profile val   = static_cast<profile>(v);
-		auto    index = profiles.find(val);
-		if (index != profiles.end())
-			return index->second;
-		return std::string("<Unknown>");
-	});
-	::ffmpeg::tools::print_av_option_string(context, "level", "      Level", [](int64_t v) {
-		level val   = static_cast<level>(v);
-		auto  index = levels.find(val);
-		if (index != levels.end())
-			return index->second;
-		return std::string("<Unknown>");
-	});
+	::ffmpeg::tools::print_av_option_string2(context, context->priv_data, "profile", "      Profile",
+											 [](int64_t v, std::string_view o) { return std::string(o); });
+	::ffmpeg::tools::print_av_option_string2(context, context->priv_data, "level", "      Level",
+											 [](int64_t v, std::string_view o) { return std::string(o); });
 }
 
 void nvenc_h264_handler::get_encoder_properties(obs_properties_t* props, const AVCodec* codec)

--- a/source/encoders/handlers/nvenc_hevc_handler.cpp
+++ b/source/encoders/handlers/nvenc_hevc_handler.cpp
@@ -139,27 +139,12 @@ void nvenc_hevc_handler::log_options(obs_data_t* settings, const AVCodec* codec,
 	nvenc::log_options(settings, codec, context);
 
 	DLOG_INFO("[%s]     H.265/HEVC:", codec->name);
-	::ffmpeg::tools::print_av_option_string(context, "profile", "      Profile", [](int64_t v) {
-		profile val   = static_cast<profile>(v);
-		auto    index = profiles.find(val);
-		if (index != profiles.end())
-			return index->second;
-		return std::string("<Unknown>");
-	});
-	::ffmpeg::tools::print_av_option_string(context, "level", "      Level", [](int64_t v) {
-		level val   = static_cast<level>(v);
-		auto  index = levels.find(val);
-		if (index != levels.end())
-			return index->second;
-		return std::string("<Unknown>");
-	});
-	::ffmpeg::tools::print_av_option_string(context, "tier", "      Tier", [](int64_t v) {
-		tier val   = static_cast<tier>(v);
-		auto index = tiers.find(val);
-		if (index != tiers.end())
-			return index->second;
-		return std::string("<Unknown>");
-	});
+	::ffmpeg::tools::print_av_option_string2(context, "profile", "      Profile",
+											 [](int64_t v, std::string_view o) { return std::string(o); });
+	::ffmpeg::tools::print_av_option_string2(context, "level", "      Level",
+											 [](int64_t v, std::string_view o) { return std::string(o); });
+	::ffmpeg::tools::print_av_option_string2(context, "tier", "      Tier",
+											 [](int64_t v, std::string_view o) { return std::string(o); });
 }
 
 void nvenc_hevc_handler::get_encoder_properties(obs_properties_t* props, const AVCodec* codec)

--- a/source/encoders/handlers/nvenc_shared.cpp
+++ b/source/encoders/handlers/nvenc_shared.cpp
@@ -701,22 +701,10 @@ void nvenc::log_options(obs_data_t*, const AVCodec* codec, AVCodecContext* conte
 	using namespace ::ffmpeg;
 
 	DLOG_INFO("[%s]   Nvidia NVENC:", codec->name);
-	tools::print_av_option_string(context, "preset", "    Preset", [](int64_t v) {
-		preset      val   = static_cast<preset>(v);
-		std::string name  = "<Default>";
-		auto        index = preset_to_opt.find(val);
-		if (index != preset_to_opt.end())
-			name = index->second;
-		return name;
-	});
-	tools::print_av_option_string(context, "rc", "    Rate Control", [](int64_t v) {
-		ratecontrolmode val   = static_cast<ratecontrolmode>(v);
-		std::string     name  = "<Default>";
-		auto            index = ratecontrolmode_to_opt.find(val);
-		if (index != ratecontrolmode_to_opt.end())
-			name = index->second;
-		return name;
-	});
+	tools::print_av_option_string2(context, "preset", "    Preset",
+								   [](int64_t v, std::string_view o) { return std::string(o); });
+	tools::print_av_option_string2(context, "rc", "    Rate Control",
+								   [](int64_t v, std::string_view o) { return std::string(o); });
 	tools::print_av_option_bool(context, "2pass", "      Two Pass");
 	tools::print_av_option_int(context, "rc-lookahead", "      Look-Ahead", "Frames");
 	tools::print_av_option_bool(context, "no-scenecut", "      Adaptive I-Frames", true);
@@ -738,14 +726,8 @@ void nvenc::log_options(obs_data_t*, const AVCodec* codec, AVCodecContext* conte
 	tools::print_av_option_int(context, "init_qpB", "        B-Frame", "");
 
 	tools::print_av_option_int(context, "bf", "    B-Frames", "Frames");
-	tools::print_av_option_string(context, "b_ref_mode", "      Reference Mode", [](int64_t v) {
-		b_ref_mode  val   = static_cast<b_ref_mode>(v);
-		std::string name  = "<Default>";
-		auto        index = b_ref_mode_to_opt.find(val);
-		if (index != b_ref_mode_to_opt.end())
-			name = index->second;
-		return name;
-	});
+	tools::print_av_option_string2(context, "b_ref_mode", "      Reference Mode",
+								   [](int64_t v, std::string_view o) { return std::string(o); });
 
 	DLOG_INFO("[%s]     Adaptive Quantization:", codec->name);
 	if (strcmp(codec->name, "h264_nvenc") == 0) {

--- a/source/ffmpeg/tools.hpp
+++ b/source/ffmpeg/tools.hpp
@@ -79,4 +79,9 @@ namespace ffmpeg::tools {
 	void print_av_option_string(AVCodecContext* ctx_codec, void* ctx_option, const char* option, std::string text,
 								std::function<std::string(int64_t)> decoder);
 
+	void print_av_option_string2(AVCodecContext* context, std::string_view option, std::string_view text,
+								 std::function<std::string(int64_t, std::string_view)> decoder);
+	void print_av_option_string2(AVCodecContext* ctx_codec, void* ctx_option, std::string_view option,
+								 std::string_view text, std::function<std::string(int64_t, std::string_view)> decoder);
+
 } // namespace ffmpeg::tools


### PR DESCRIPTION
<!-- Hi, thank you for taking the time to submit a pull request. -->
<!-- Please make sure that you fill this out in it's entirety. -->

### Description
Fixed the "profile", "level" and other string value fields to show the correct setting instead of showing incorrect values.
<!-- Describe your changes in as much detail as possible. -->
<!-- But please exclude your personal history from this. Only describe the changes -->

### Related Issues
- #297 NVENC H.264 shows `main` for High profile due to mismatching values.
<!-- - #0000 Name of Issue -->
<!-- - #0001 Name of Issue -->
