### PR TITLE
ffmpeg/tools: Ensure we aren't comparing against a nullptr

### DIFF
--- a/source/ffmpeg/tools.cpp
+++ b/source/ffmpeg/tools.cpp
@@ -359,10 +359,12 @@ void tools::print_av_option_string2(AVCodecContext* ctx_codec, void* ctx_option,
 
 		// Find the unit for the option.
 		auto* unitopt = av_opt_find(ctx_option, option.data(), nullptr, 0, AV_OPT_SEARCH_CHILDREN);
-		if (unitopt) {
+		if (unitopt && unitopt->unit) {
 			std::string_view optname;
-			for (auto* opt = unitopt;
-				 (opt = av_opt_next(ctx_option, opt)) != nullptr && (strcmp(unitopt->unit, opt->unit) == 0);) {
+			for (auto* opt = unitopt; (opt = av_opt_next(ctx_option, opt)) != nullptr;) {
+				if (opt->unit && (strcmp(unitopt->unit, opt->unit) != 0))
+					continue;
+
 				if (opt->default_val.i64 == v)
 					optname = opt->name;
 			}


### PR DESCRIPTION
<!-- Hi, thank you for taking the time to submit a pull request. -->
<!-- Please make sure that you fill this out in it's entirety. -->

### Description
Using `strcmp` to compare against a nullptr results in a crash on Windows.
<!-- Describe your changes in as much detail as possible. -->
<!-- But please exclude your personal history from this. Only describe the changes -->

### Related Issues
- #305 Crash in strcmp after updating to 0.8.2
<!-- - #0000 Name of Issue -->
<!-- - #0001 Name of Issue -->
