### PR TITLE
FFmpeg: Don't list encoders that aren't supported on the System

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -493,6 +493,8 @@ list(APPEND PROJECT_PRIVATE_SOURCE
 	"source/util/utility.hpp"
 	"source/util/utility.cpp"
 	"source/util/util-event.hpp"
+	"source/util/util-library.cpp"
+	"source/util/util-library.hpp"
 	"source/util/util-profiler.cpp"
 	"source/util/util-profiler.hpp"
 	"source/util/util-threadpool.cpp"

--- a/source/common.hpp
+++ b/source/common.hpp
@@ -47,6 +47,7 @@
 #include "config.hpp"
 #include "strings.hpp"
 #include "version.hpp"
+#include "util/util-library.hpp"
 #include "util/util-math.hpp"
 #include "util/util-profiler.hpp"
 #include "util/util-threadpool.hpp"

--- a/source/encoders/encoder-ffmpeg.cpp
+++ b/source/encoders/encoder-ffmpeg.cpp
@@ -1097,6 +1097,11 @@ const AVCodec* ffmpeg_factory::get_avcodec()
 	return _avcodec;
 }
 
+obs_encoder_info* streamfx::encoder::ffmpeg::ffmpeg_factory::get_info()
+{
+	return &_info;
+}
+
 ffmpeg_manager::ffmpeg_manager() : _factories(), _handlers(), _debug_handler()
 {
 	// Handlers

--- a/source/encoders/encoder-ffmpeg.hpp
+++ b/source/encoders/encoder-ffmpeg.hpp
@@ -147,6 +147,8 @@ namespace streamfx::encoder::ffmpeg {
 
 		public:
 		const AVCodec* get_avcodec();
+
+		obs_encoder_info* get_info();
 	};
 
 	class ffmpeg_manager {

--- a/source/encoders/handlers/nvenc_h264_handler.cpp
+++ b/source/encoders/handlers/nvenc_h264_handler.cpp
@@ -59,9 +59,11 @@ std::map<level, std::string> levels{
 	{level::L4_1, "4.1"}, {level::L4_2, "4.2"},   {level::L5_0, "5.0"}, {level::L5_1, "5.1"},
 };
 
-void nvenc_h264_handler::adjust_info(ffmpeg_factory*, const AVCodec*, std::string&, std::string& name, std::string&)
+void nvenc_h264_handler::adjust_info(ffmpeg_factory* fac, const AVCodec*, std::string&, std::string& name, std::string&)
 {
 	name = "NVIDIA NVENC H.264/AVC (via FFmpeg)";
+	if (!nvenc::is_available())
+		fac->get_info()->caps |= OBS_ENCODER_CAP_DEPRECATED;
 }
 
 void nvenc_h264_handler::get_defaults(obs_data_t* settings, const AVCodec* codec, AVCodecContext* context, bool)

--- a/source/encoders/handlers/nvenc_hevc_handler.cpp
+++ b/source/encoders/handlers/nvenc_hevc_handler.cpp
@@ -59,9 +59,11 @@ std::map<level, std::string> levels{
 	{level::L6_0, "6.0"}, {level::L6_1, "6.1"}, {level::L6_2, "6.2"},
 };
 
-void nvenc_hevc_handler::adjust_info(ffmpeg_factory*, const AVCodec*, std::string&, std::string& name, std::string&)
+void nvenc_hevc_handler::adjust_info(ffmpeg_factory* fac, const AVCodec*, std::string&, std::string& name, std::string&)
 {
 	name = "NVIDIA NVENC H.265/HEVC (via FFmpeg)";
+	if (!nvenc::is_available())
+		fac->get_info()->caps |= OBS_ENCODER_CAP_DEPRECATED;
 }
 
 void nvenc_hevc_handler::get_defaults(obs_data_t* settings, const AVCodec* codec, AVCodecContext* context, bool)

--- a/source/encoders/handlers/nvenc_shared.cpp
+++ b/source/encoders/handlers/nvenc_shared.cpp
@@ -20,15 +20,10 @@
 // SOFTWARE.
 
 #include "nvenc_shared.hpp"
-#include "strings.hpp"
-#include <algorithm>
-#include "../codecs/hevc.hpp"
-#include "../encoder-ffmpeg.hpp"
+#include "encoders/encoder-ffmpeg.hpp"
 #include "ffmpeg/tools.hpp"
-#include "plugin.hpp"
 
 extern "C" {
-#include <obs-module.h>
 #pragma warning(push)
 #pragma warning(disable : 4244)
 #include <libavutil/opt.h>
@@ -154,6 +149,25 @@ std::map<nvenc::b_ref_mode, std::string> nvenc::b_ref_mode_to_opt{
 	{nvenc::b_ref_mode::EACH, "each"},
 	{nvenc::b_ref_mode::MIDDLE, "middle"},
 };
+
+bool streamfx::encoder::ffmpeg::handler::nvenc::is_available()
+{
+#if defined(D_PLATFORM_WINDOWS)
+#if defined(D_PLATFORM_64BIT)
+	std::filesystem::path lib_name = "nvEncodeAPI64.dll";
+#else
+	std::filesystem::path lib_name = "nvEncodeAPI.dll";
+#endif
+#else
+	std::filesystem::path lib_name = "libnvidia-encode.so.1";
+#endif
+	try {
+		util::library::load(lib_name);
+		return true;
+	} catch (...) {
+		return false;
+	}
+}
 
 void nvenc::override_update(ffmpeg_instance* instance, obs_data_t*)
 {

--- a/source/encoders/handlers/nvenc_shared.hpp
+++ b/source/encoders/handlers/nvenc_shared.hpp
@@ -20,7 +20,7 @@
 // SOFTWARE.
 
 #pragma once
-#include <map>
+#include "common.hpp"
 #include "handler.hpp"
 
 extern "C" {
@@ -89,6 +89,8 @@ namespace streamfx::encoder::ffmpeg::handler::nvenc {
 	extern std::map<b_ref_mode, std::string> b_ref_modes;
 
 	extern std::map<b_ref_mode, std::string> b_ref_mode_to_opt;
+
+	bool is_available();
 
 	void override_update(ffmpeg_instance* instance, obs_data_t* settings);
 

--- a/source/util/util-library.cpp
+++ b/source/util/util-library.cpp
@@ -1,0 +1,107 @@
+// Copyright (c) 2020 Michael Fabian Dirks <info@xaymar.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "util-library.hpp"
+#include <unordered_map>
+
+#if defined(_WIN32) || defined(_WIN64) || defined(__CYGWIN__) // Windows
+#define ST_WINDOWS
+#else
+#define ST_UNIX
+#endif
+
+#if defined(ST_WINDOWS)
+#include <Windows.h>
+#elif defined(ST_UNIX)
+#include <dlfcn.h>
+#endif
+
+util::library::library(std::filesystem::path file) : _library(nullptr)
+{
+#if defined(ST_WINDOWS)
+	SetLastError(ERROR_SUCCESS);
+	_library = reinterpret_cast<void*>(LoadLibraryW(file.wstring().c_str()));
+	if (!_library) {
+		DWORD error = GetLastError();
+		if (error != ERROR_PROC_NOT_FOUND) {
+			PSTR        message = NULL;
+			std::string ex      = "Failed to load library.";
+			FormatMessageA(FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS | FORMAT_MESSAGE_ALLOCATE_BUFFER,
+						   NULL, error, MAKELANGID(LANG_ENGLISH, SUBLANG_ENGLISH_US), (LPSTR)&message, 0, NULL);
+			if (message) {
+				ex = message;
+				LocalFree(message);
+				throw std::runtime_error(ex);
+			}
+		}
+		throw std::runtime_error("Failed to load library.");
+	}
+#elif defined(ST_UNIX)
+	_library = dlopen(file.string().c_str(), RTLD_LAZY);
+	if (!_library) {
+		if (char* error = dlerror(); error)
+			throw std::runtime_error(error);
+		else
+			throw std::runtime_error("Failed to load library.");
+	}
+#endif
+}
+
+util::library::~library()
+{
+#if defined(ST_WINDOWS)
+	FreeLibrary(reinterpret_cast<HMODULE>(_library));
+#elif defined(ST_UNIX)
+	dlclose(_library);
+#endif
+}
+
+void* util::library::load_symbol(std::string name)
+{
+#if defined(ST_WINDOWS)
+	return reinterpret_cast<void*>(GetProcAddress(reinterpret_cast<HMODULE>(_library), name.c_str()));
+#elif defined(ST_UNIX)
+	return reinterpret_cast<void*>(dlsym(_library, name.c_str()));
+#endif
+}
+
+static std::unordered_map<std::string, std::weak_ptr<::util::library>> libraries;
+
+std::shared_ptr<::util::library> util::library::load(std::filesystem::path file)
+{
+	std::string utf8_name = file.string();
+
+	auto kv = libraries.find(utf8_name);
+	if (kv != libraries.end()) {
+		if (auto ptr = kv->second.lock(); ptr)
+			return ptr;
+		libraries.erase(kv);
+	}
+
+	auto ptr = std::make_shared<::util::library>(file);
+	libraries.emplace(utf8_name, ptr);
+
+	return ptr;
+}
+
+std::shared_ptr<::util::library> util::library::load(std::string name)
+{
+	return load(std::filesystem::path(name));
+}

--- a/source/util/util-library.hpp
+++ b/source/util/util-library.hpp
@@ -1,0 +1,40 @@
+// Copyright (c) 2020 Michael Fabian Dirks <info@xaymar.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma once
+#include <filesystem>
+#include <memory>
+#include <string>
+
+namespace util {
+	class library {
+		void* _library;
+
+		public:
+		library(std::filesystem::path file);
+		~library();
+
+		void* load_symbol(std::string name);
+
+		static std::shared_ptr<::util::library> load(std::filesystem::path file);
+
+		static std::shared_ptr<::util::library> load(std::string name);
+	};
+} // namespace util


### PR DESCRIPTION
<!-- Hi, thank you for taking the time to submit a pull request. -->
<!-- Please make sure that you fill this out in it's entirety. -->

### Description
Adds a utility library to load libraries across platforms, a function to get the info object from encoders, and a test for NVENC to check if the platform has the necessary libraries to encode with NVENC.
<!-- Describe your changes in as much detail as possible. -->
<!-- But please exclude your personal history from this. Only describe the changes -->

### Related Issues
<!-- - #0000 Name of Issue -->
<!-- - #0001 Name of Issue -->
