### PR TITLE
ffmpeg/tools: Set correct information when encoding

### DIFF
--- a/source/common.hpp
+++ b/source/common.hpp
@@ -32,6 +32,7 @@
 
 // Common C++ includes
 #include <algorithm>
+#include <array>
 #include <limits>
 #include <map>
 #include <memory>

--- a/source/encoders/encoder-ffmpeg.cpp
+++ b/source/encoders/encoder-ffmpeg.cpp
@@ -586,9 +586,10 @@ bool ffmpeg_instance::get_sei_data(uint8_t** data, size_t* size)
 
 void ffmpeg_instance::get_video_info(struct video_scale_info* info)
 {
-	info->width  = _scaler.get_source_width();
-	info->height = _scaler.get_source_height();
-	info->format = ::ffmpeg::tools::avpixelformat_to_obs_videoformat(_scaler.get_source_format());
+	if (!is_hardware_encode()) {
+		// Override input with supported format if software encode.
+		info->format = ::ffmpeg::tools::avpixelformat_to_obs_videoformat(_scaler.get_source_format());
+	}
 }
 
 int ffmpeg_instance::receive_packet(bool* received_packet, struct encoder_packet* packet)

--- a/source/encoders/encoder-ffmpeg.cpp
+++ b/source/encoders/encoder-ffmpeg.cpp
@@ -95,7 +95,8 @@ ffmpeg_instance::ffmpeg_instance(obs_data_t* settings, obs_encoder_t* self, bool
 	if (is_hw) {
 		// Abort if user specified manual override.
 		if ((static_cast<AVPixelFormat>(obs_data_get_int(settings, KEY_FFMPEG_COLORFORMAT)) != AV_PIX_FMT_NONE)
-			|| (obs_data_get_int(settings, KEY_FFMPEG_GPU) != -1) || (obs_encoder_scaling_enabled(_self))) {
+			|| (obs_data_get_int(settings, KEY_FFMPEG_GPU) != -1) || (obs_encoder_scaling_enabled(_self))
+			|| (video_output_get_info(obs_encoder_video(_self))->format != VIDEO_FORMAT_NV12)) {
 			throw std::runtime_error(
 				"Selected settings prevent the use of hardware encoding, falling back to software.");
 		}

--- a/source/ffmpeg/tools.hpp
+++ b/source/ffmpeg/tools.hpp
@@ -43,20 +43,20 @@ namespace ffmpeg::tools {
 	const char* get_error_description(int error);
 
 	AVPixelFormat obs_videoformat_to_avpixelformat(video_format v);
-
-	video_format avpixelformat_to_obs_videoformat(AVPixelFormat v);
+	video_format  avpixelformat_to_obs_videoformat(AVPixelFormat v);
 
 	AVPixelFormat get_least_lossy_format(const AVPixelFormat* haystack, AVPixelFormat needle);
 
-	AVColorSpace obs_videocolorspace_to_avcolorspace(video_colorspace v);
-
-	AVColorRange obs_videorangetype_to_avcolorrange(video_range_type v);
+	AVColorRange                  obs_to_av_color_range(video_range_type v);
+	AVColorSpace                  obs_to_av_color_space(video_colorspace v);
+	AVColorPrimaries              obs_to_av_color_primary(video_colorspace v);
+	AVColorTransferCharacteristic obs_to_av_color_transfer_characteristics(video_colorspace v);
 
 	bool can_hardware_encode(const AVCodec* codec);
 
 	std::vector<AVPixelFormat> get_software_formats(const AVPixelFormat* list);
 
-	void setup_obs_color(video_colorspace colorspace, video_range_type range, AVCodecContext* context);
+	void context_setup_from_obs(const video_output_info* voi, AVCodecContext* context);
 
 	const char* get_std_compliance_name(int compliance);
 


### PR DESCRIPTION
<!-- Hi, thank you for taking the time to submit a pull request. -->
<!-- Please make sure that you fill this out in it's entirety. -->

### Description
Improves the previous logic and makes it compatible with the new additions in 26.x, such as sRGB. This was previously broken as the focus was on existing features which could be tested without requiring a compiler to be installed.

Incorrect understanding of how sRGB works with RGB and YCC/YUV formats also caused sRGB to be treated as RGB when I444 was selected. This should also now be fixed, hopefully permanently.

### Testing Required
#### Color Formats
|              | NV12 | I420 | I444             | RGB |
|--------------|------|------|------------------|-----|
| H.264 4:2:0  | OK   | OK   | OK               | OK  |
| H.264 4:4:4  |      |      | OK               | OK  |
| H.265 4:2:0  |      |      |                  |     |
| H.265 4:4:4  |      |      |                  |     |
| ProRES 4:2:2 | OK   | OK   | FAIL<sup>1</sup> | OK  |
| ProRES 4:4:4 | OK   | OK   | OK               | OK  |

1. 4:4:4 to 4:2:2 conversion causes weird colors.

#### Color Spaces
|              | 601 | 709 | sRGB |
|--------------|-----|-----|------|
| H.264 4:2:0  | OK  | OK  | OK   |
| H.264 4:4:4  | OK  | OK  | OK   |
| H.265 4:2:0  |     |     |      |
| H.265 4:4:4  |     |     |      |
| ProRES 4:2:2 | OK  | OK  | OK   |
| ProRES 4:4:4 | OK  | OK  | OK   |

### Related Issues
- #331 Incorrect format tagging for sRGB.
<!-- - #0000 Name of Issue -->
<!-- - #0001 Name of Issue -->
