### PR TITLE
Filter/Dynamic Mask: Add active and showing reference to input source

### DIFF
--- a/source/filters/filter-dynamic-mask.hpp
+++ b/source/filters/filter-dynamic-mask.hpp
@@ -26,6 +26,7 @@
 #include "obs/obs-source-factory.hpp"
 #include "obs/obs-source-tracker.hpp"
 #include "obs/obs-source.hpp"
+#include "obs/obs-tools.hpp"
 
 namespace streamfx::filter::dynamic_mask {
 	enum class channel : int8_t { Invalid = -1, Red, Green, Blue, Alpha };
@@ -39,10 +40,12 @@ namespace streamfx::filter::dynamic_mask {
 		std::shared_ptr<gs::rendertarget> _filter_rt;
 		std::shared_ptr<gs::texture>      _filter_texture;
 
-		bool                                    _have_input_texture;
-		std::shared_ptr<obs::deprecated_source> _input;
-		std::shared_ptr<gfx::source_texture>    _input_capture;
-		std::shared_ptr<gs::texture>            _input_texture;
+		bool                                        _have_input_texture;
+		std::shared_ptr<obs::deprecated_source>     _input;
+		std::shared_ptr<gfx::source_texture>        _input_capture;
+		std::shared_ptr<gs::texture>                _input_texture;
+		std::shared_ptr<obs::tools::visible_source> _input_vs;
+		std::shared_ptr<obs::tools::active_source>  _input_ac;
 
 		bool                              _have_final_texture;
 		std::shared_ptr<gs::rendertarget> _final_rt;
@@ -74,6 +77,14 @@ namespace streamfx::filter::dynamic_mask {
 
 		virtual void video_tick(float_t _time) override;
 		virtual void video_render(gs_effect_t* effect) override;
+
+		void enum_active_sources(obs_source_enum_proc_t enum_callback, void* param) override;
+		void enum_all_sources(obs_source_enum_proc_t enum_callback, void* param) override;
+
+		void show() override;
+		void hide() override;
+		void activate() override;
+		void deactivate() override;
 	};
 
 	class dynamic_mask_factory : public obs::source_factory<filter::dynamic_mask::dynamic_mask_factory,

--- a/source/obs/obs-tools.hpp
+++ b/source/obs/obs-tools.hpp
@@ -36,6 +36,35 @@ namespace obs {
 
 			std::shared_ptr<obs_source_t> get();
 		};
+
+		// Class to manage
+		class active_source {
+			obs_source_t* _child;
+
+			public:
+			active_source(obs_source_t* child) : _child(child)
+			{
+				obs_source_inc_active(_child);
+			}
+			virtual ~active_source()
+			{
+				obs_source_dec_active(_child);
+			}
+		};
+
+		class visible_source {
+			obs_source_t* _child;
+
+			public:
+			visible_source(obs_source_t* child) : _child(child)
+			{
+				obs_source_inc_showing(_child);
+			}
+			virtual ~visible_source()
+			{
+				obs_source_dec_showing(_child);
+			}
+		};
 	} // namespace tools
 
 	inline void obs_source_deleter(obs_source_t* v)


### PR DESCRIPTION
<!-- Hi, thank you for taking the time to submit a pull request. -->
<!-- Please make sure that you fill this out in it's entirety. -->

### Description
For an unknown reason, libOBS ignores active child sources of filters on sources, resulting in them being paused when they really should be active instead. This results in Dynamic Mask freezing instead of working like expected.
<!-- Describe what the PR does in detail, and why this is necessary. -->
<!-- Please do not include any personal history, or personal reasons - keep things objective, not subjective. -->

#### Old Behavior
The input source would pause if not in the same scene.
<!-- Describe the old behavior -->
<!-- Attach videos or screenshots of the old behavior -->

#### New Behavior
The input source no longer pauses if not in the same scene.
<!-- Describe the new behavior -->
<!-- Attach videos or screenshots of the new behavior -->

### Related Issues
<!-- Is this PR related to another PR or Issue? List them here. -->
<!-- - #0000 Name of Issue -->
<!-- - #0001 Name of Issue -->
- Fixes #384
