### PR TITLE
filter/shader: Initialize with given data

### DIFF
--- a/source/filters/filter-shader.cpp
+++ b/source/filters/filter-shader.cpp
@@ -30,6 +30,8 @@ shader_instance::shader_instance(obs_data_t* data, obs_source_t* self) : obs::so
 {
 	_fx = std::make_shared<gfx::shader::shader>(self, gfx::shader::shader_mode::Filter);
 	_rt = std::make_shared<gs::rendertarget>(GS_RGBA, GS_ZS_NONE);
+
+	update(data);
 }
 
 shader_instance::~shader_instance() {}


### PR DESCRIPTION
<!-- Hi, thank you for taking the time to submit a pull request. -->
<!-- Please make sure that you fill this out in it's entirety. -->

### Description
Correctly initialized Shader filters with the given obs_data_t object in the create call. This enables scene/source duplication to work correctly, instead of staying blank, and allows third-party plugins to pass configurations in the create call.

<!-- Describe what the PR does in detail, and why this is necessary. -->
<!-- Please do not include any personal history, or personal reasons - keep things objective, not subjective. -->

#### Old Behavior
Shader filters would not be able to be duplicated and stayed dark, despite being able to fully duplicate.
<!-- Describe the old behavior -->
<!-- Attach videos or screenshots of the old behavior -->

#### New Behavior
Shader filters now duplicate correctly.
<!-- Describe the new behavior -->
<!-- Attach videos or screenshots of the new behavior -->

### Related Issues
<!-- Is this PR related to another PR or Issue? List them here. -->
<!-- - #0000 Name of Issue -->
- Fixes #315
