### PR TITLE
sources/mirror: Clamp minimum size to 1x1

### DIFF
--- a/source/sources/source-mirror.cpp
+++ b/source/sources/source-mirror.cpp
@@ -85,12 +85,12 @@ mirror_instance::~mirror_instance()
 
 uint32_t mirror_instance::get_width()
 {
-	return _source_size.first;
+	return _source_size.first ? _source_size.first : 1;
 }
 
 uint32_t mirror_instance::get_height()
 {
-	return _source_size.second;
+	return _source_size.second ? _source_size.second : 1;
 }
 
 void mirror_instance::load(obs_data_t* data)


### PR DESCRIPTION
<!-- Hi, thank you for taking the time to submit a pull request. -->
<!-- Please make sure that you fill this out in it's entirety. -->

### Description
This works around an issue in our code with asynchronous or delayed sources.
<!-- Describe what the PR does in detail, and why this is necessary. -->
<!-- Please do not include any personal history, or personal reasons - keep things objective, not subjective. -->

#### Old Behavior
Source Mirror doesn't load due to the source size being 0x0
<!-- Describe the old behavior -->
<!-- Attach videos or screenshots of the old behavior -->

#### New Behavior
Source Mirror loads, but is always at least 1x1.
<!-- Describe the new behavior -->
<!-- Attach videos or screenshots of the new behavior -->

### Related Issues
<!-- Is this PR related to another PR or Issue? List them here. -->
<!-- - #0000 Name of Issue -->
<!-- - #0001 Name of Issue -->
