### PR TITLE
ffmpeg/tools: Adjust to match ffmpeg-mux color settings

### DIFF
--- a/source/ffmpeg/tools.cpp
+++ b/source/ffmpeg/tools.cpp
@@ -143,11 +143,11 @@ AVColorRange tools::obs_to_av_color_range(video_range_type v)
 AVColorSpace tools::obs_to_av_color_space(video_colorspace v)
 {
 	switch (v) {
-	case VIDEO_CS_601:
-		return AVCOL_SPC_BT470BG;
+	case VIDEO_CS_601: // BT.601
+		return AVCOL_SPC_SMPTE170M;
 	case VIDEO_CS_DEFAULT:
-	case VIDEO_CS_709:
-	case VIDEO_CS_SRGB:
+	case VIDEO_CS_709:  // BT.709
+	case VIDEO_CS_SRGB: // sRGB
 		return AVCOL_SPC_BT709;
 	default:
 		throw std::invalid_argument("Unknown Color Space");
@@ -157,11 +157,11 @@ AVColorSpace tools::obs_to_av_color_space(video_colorspace v)
 AVColorPrimaries ffmpeg::tools::obs_to_av_color_primary(video_colorspace v)
 {
 	switch (v) {
-	case VIDEO_CS_601:
-		return AVCOL_PRI_BT470BG;
+	case VIDEO_CS_601: // BT.601
+		return AVCOL_PRI_SMPTE170M;
 	case VIDEO_CS_DEFAULT:
-	case VIDEO_CS_709:
-	case VIDEO_CS_SRGB:
+	case VIDEO_CS_709:  // BT.709
+	case VIDEO_CS_SRGB: // sRGB
 		return AVCOL_PRI_BT709;
 	default:
 		throw std::invalid_argument("Unknown Color Primaries");
@@ -171,13 +171,13 @@ AVColorPrimaries ffmpeg::tools::obs_to_av_color_primary(video_colorspace v)
 AVColorTransferCharacteristic ffmpeg::tools::obs_to_av_color_transfer_characteristics(video_colorspace v)
 {
 	switch (v) {
-	case VIDEO_CS_601:
-		return AVCOL_TRC_SMPTE240M;
+	case VIDEO_CS_601: // BT.601
+		return AVCOL_TRC_SMPTE170M;
 	case VIDEO_CS_DEFAULT:
-	case VIDEO_CS_709:
+	case VIDEO_CS_709: // BT.709
 		return AVCOL_TRC_BT709;
-	case VIDEO_CS_SRGB: // sRGB with Gamma 2.2
-		return AVCOL_TRC_GAMMA22;
+	case VIDEO_CS_SRGB: // sRGB with IEC 61966-2-1
+		return AVCOL_TRC_IEC61966_2_1;
 	default:
 		throw std::invalid_argument("Unknown Color Transfer Characteristics");
 	}


### PR DESCRIPTION
<!-- Hi, thank you for taking the time to submit a pull request. -->
<!-- Please make sure that you fill this out in it's entirety. -->

### Description
The 'obs-ffmpeg-mux.c' file specifies different color paramters than StreamFX does. This causes remuxing to go haywire, and editors that trust these tags suddenly spew out bad colors for BT.601 and sRGB.
<!-- Describe what the PR does in detail, and why this is necessary. -->
<!-- Please do not include any personal history, or personal reasons - keep things objective, not subjective. -->

#### Old Behavior
- sRGB was tagged as Gamma 2.2, but should have a tag of IEC61966-2-1
- BT.601 was tagged SMPTE240M, but should have a tag of SMPTE170M
<!-- Describe the old behavior -->
<!-- Attach videos or screenshots of the old behavior -->

#### New Behavior
- sRGB is now tagged as IEC61966-2-1 again after PR #478 broke it.
- BT.601 is now tagged SMPTE170M.
<!-- Describe the new behavior -->
<!-- Attach videos or screenshots of the new behavior -->

### Related Issues
<!-- Is this PR related to another PR or Issue? List them here. -->
<!-- - #0000 Name of Issue -->
<!-- - #0001 Name of Issue -->
