### PR TITLE
filters/color-grading: Use explicit matrix initializer for GLSL support

### DIFF
--- a/data/effects/color-grade.effect
+++ b/data/effects/color-grade.effect
@@ -75,11 +75,11 @@ float3 grade_tint(float3 v) {
 	} else if (pTintDetection == TINT_DETECTION_HSL) { // HSL
 		value = RGBtoHSL(v).z;
 	} else if (pTintDetection == TINT_DETECTION_YUV_SDR) { // YUV HD SDR
-		const float3x3 mYUV709n = { // Normalized
+		const float3x3 mYUV709n = float3x3( // Normalized
 			0.2126, 0.7152, 0.0722,
 			-0.1145721060573399, -0.3854278939426601, 0.5,
 			0.5, -0.4541529083058166, -0.0458470916941834
-		};
+		);
 		value = RGBtoYUV(v, mYUV709n).r;
 	}
 
@@ -110,8 +110,6 @@ float3 grade_colorcorrection(float3 v) {
 	v1.g *= pCorrection.g; // Saturation Multiplier
 	v1.b *= pCorrection.b; // Lightness Multiplier
 	float3 v2 = HSVtoRGB(v1);
-
-
 	return v2;
 };
 


### PR DESCRIPTION
<!-- Hi, thank you for taking the time to submit a pull request. -->
<!-- Please make sure that you fill this out in it's entirety. -->

### Description
<!-- Describe what the PR does in detail, and why this is necessary. -->
<!-- Please do not include any personal history, or personal reasons - keep things objective, not subjective. -->

#### Old Behavior
- Used guessed initializer, which breaks with GLSL.
<!-- Describe the old behavior -->
<!-- Attach videos or screenshots of the old behavior -->

#### New Behavior
- Explicit initializer, works in GLSL.
<!-- Describe the new behavior -->
<!-- Attach videos or screenshots of the new behavior -->

### Related Issues
<!-- Is this PR related to another PR or Issue? List them here. -->
<!-- - #0000 Name of Issue -->
<!-- - #0001 Name of Issue -->
- #510
