### PR TITLE
filter/blur: Don't pass bool as TEXCOORD1

### DIFF
--- a/data/effects/blur/box-linear.effect
+++ b/data/effects/blur/box-linear.effect
@@ -65,20 +65,19 @@ struct VertDataIn {
 struct VertDataOut {
 	float4 pos  : POSITION;
 	float2 uv   : TEXCOORD0;
-	bool is_odd : TEXCOORD1;
 };
 
 VertDataOut VSDefault(VertDataIn vtx) {
 	VertDataOut vert_out;
 	vert_out.pos = mul(float4(vtx.pos.xyz, 1.0), ViewProj);
 	vert_out.uv  = vtx.uv;
-	vert_out.is_odd = ((int(round(pSize)) % 2) == 1);
 	return vert_out;
 }
 
 // Blur 1 Dimensional
 float4 PSBlur1D(VertDataOut vtx) : TARGET {
 	float4 final = pImage.Sample(linearSampler, vtx.uv);
+	bool is_odd = ((int(round(pSize)) % 2) == 1);
 
 	// y = yes, s = skip, b = break
 	// Size-> | 1| 2| 3| 4| 5| 6| 7|
@@ -104,7 +103,7 @@ float4 PSBlur1D(VertDataOut vtx) : TARGET {
 		final += pImage.Sample(linearSampler, vtx.uv + nstep) * 2.;
 		final += pImage.Sample(linearSampler, vtx.uv - nstep) * 2.;
 	}
-	if (vtx.is_odd) {
+	if (is_odd) {
 		float2 nstep = (pImageTexel * pStepScale) * pSize;
 		final += pImage.Sample(linearSampler, vtx.uv + nstep);
 		final += pImage.Sample(linearSampler, vtx.uv - nstep);

--- a/data/effects/blur/gaussian-linear.effect
+++ b/data/effects/blur/gaussian-linear.effect
@@ -71,14 +71,12 @@ struct VertDataIn {
 struct VertDataOut {
 	float4 pos  : POSITION;
 	float2 uv   : TEXCOORD0;
-	bool is_odd : TEXCOORD1;
 };
 
 VertDataOut VSDefault(VertDataIn vtx) {
 	VertDataOut vert_out;
 	vert_out.pos = mul(float4(vtx.pos.xyz, 1.0), ViewProj);
 	vert_out.uv  = vtx.uv;
-	vert_out.is_odd = ((int(round(pSize)) % 2) == 1);
 	return vert_out;
 }
 
@@ -89,8 +87,8 @@ float GetKernelAt(int i) {
 
 // Blur 1 Dimensional
 float4 PSBlur1D(VertDataOut vtx) : TARGET {
-	float4 final = pImage.Sample(linearSampler, vtx.uv)
-		* GetKernelAt(0);
+	float4 final = pImage.Sample(linearSampler, vtx.uv) * GetKernelAt(0);
+	bool is_odd = ((int(round(pSize)) % 2) == 1);
 		
 	// y = yes, s = skip, b = break
 	// Size-> | 1| 2| 3| 4| 5| 6| 7|
@@ -118,7 +116,7 @@ float4 PSBlur1D(VertDataOut vtx) : TARGET {
 		final += pImage.Sample(linearSampler, vtx.uv + nstep) * kernel;
 		final += pImage.Sample(linearSampler, vtx.uv - nstep) * kernel;
 	}
-	if (vtx.is_odd) {
+	if (is_odd) {
 		float kernel = GetKernelAt(pSize);
 		float2 nstep = (pImageTexel * pStepScale) * pSize;
 		final += pImage.Sample(linearSampler, vtx.uv + nstep) * kernel;


### PR DESCRIPTION
<!-- Hi, thank you for taking the time to submit a pull request. -->
<!-- Please make sure that you fill this out in it's entirety. -->

### Description
Using a 'bool' as TEXCOORD1 is undefined behavior, so we should not abuse the intermediate shading storage like this.
<!-- Describe what the PR does in detail, and why this is necessary. -->
<!-- Please do not include any personal history, or personal reasons - keep things objective, not subjective. -->

### Related Issues
Fixes #559
<!-- Is this PR related to another PR or Issue? List them here. -->
<!-- - #0000 Name of Issue -->
<!-- - #0001 Name of Issue -->
