### PR TITLE
gfx/blur: Fix type mismatch in OpenGL shaders

### DIFF
--- a/data/effects/blur/box-linear.effect
+++ b/data/effects/blur/box-linear.effect
@@ -37,15 +37,12 @@
 //------------------------------------------------------------------------------
 // Defines
 //------------------------------------------------------------------------------
-#define MAX_BLUR_SIZE 128
+#define MAX_BLUR_SIZE 128u
 
 //------------------------------------------------------------------------------
 // Technique: Directional / Area
 //------------------------------------------------------------------------------
 float4 PSBlur1D(VertexInformation vtx) : TARGET {
-	float4 final = pImage.Sample(LinearClampSampler, vtx.uv);
-	bool is_odd = ((uint(round(pSize)) % 2) == 1);
-
 	// y = yes, s = skip, b = break
 	// Size-> | 1| 2| 3| 4| 5| 6| 7|
 	// -------+--+--+--+--+--+--+--+
@@ -58,19 +55,14 @@ float4 PSBlur1D(VertexInformation vtx) : TARGET {
 	// n=7    |  |  |  |  |  | b| b|
 	// n=8    |  |  |  |  |  |  |  |
 
-	// Loop unrolling is only possible with a fixed known maximum.
-	// Some compilers may unroll up to x iterations, but most will not.
-	for (int n = 1; n <= MAX_BLUR_SIZE; n+=2) {
-		// Different from normal box, early exit instead of late exit.
-		if (n >= pSize) {
-			break;
-		}
-
-		float2 nstep = (pImageTexel * pStepScale) * (n + 0.5);
+	float4 final = pImage.Sample(LinearClampSampler, vtx.uv);
+	for (uint n = 1u; (n < uint(pSize)) && (n < MAX_BLUR_SIZE); n += 2u) {
+		float2 nstep = (pImageTexel * pStepScale) * (float(n) + 0.5);
 		final += pImage.Sample(LinearClampSampler, vtx.uv + nstep) * 2.;
 		final += pImage.Sample(LinearClampSampler, vtx.uv - nstep) * 2.;
 	}
-	if (is_odd) {
+
+	if ((uint(pSize) % 2u) == 1u) {
 		float2 nstep = (pImageTexel * pStepScale) * pSize;
 		final += pImage.Sample(LinearClampSampler, vtx.uv + nstep);
 		final += pImage.Sample(LinearClampSampler, vtx.uv - nstep);

--- a/data/effects/blur/common.effect
+++ b/data/effects/blur/common.effect
@@ -81,5 +81,5 @@ float2 rotateAround(float2 pt, float2 cpt, float angle) {
 }
 
 float kernelAt(uint i) {
-	return ((float[4])(pKernel[floor(i/4)]))[i%4];
+	return pKernel[i/4u][i%4u];
 }

--- a/data/effects/blur/gaussian.effect
+++ b/data/effects/blur/gaussian.effect
@@ -9,7 +9,7 @@
 //------------------------------------------------------------------------------
 // Defines
 //------------------------------------------------------------------------------
-#define MAX_SAMPLES 128
+#define MAX_SAMPLES 128u
 
 //------------------------------------------------------------------------------
 // Technique: Directional / Area
@@ -23,20 +23,22 @@ float4 PSBlur1D(VertexInformation vtx) : TARGET {
 
 	// Calculate the actual Gaussian Blur
 	// 1. Sample the center immediately.
-	float kernel = kernelAt(0);
+	float kernel = kernelAt(0u);
 	weights += kernel;
 	float4 final = pImage.Sample(LinearClampSampler, vtx.uv) * kernel;
+
 	// 2. Then sample both + and - coordinates in one go to reduce code iterations.
-	for (uint step = 1; (step < pSize) && (step < MAX_SAMPLES); step++) {
-		float2 offset = uvstep * step;
+	for (uint step = 1u; (step < uint(pSize)) && (step < MAX_SAMPLES); step++) {
+		float2 offset = uvstep * float2(step, step);
 		kernel = kernelAt(step);
-		weights += kernel * 2;
+		weights += kernel * 2.;
 
 		final += pImage.Sample(LinearClampSampler, vtx.uv + offset) * kernel;
 		final += pImage.Sample(LinearClampSampler, vtx.uv - offset) * kernel;
 	}
+
 	// 3. Ensure we always have a total of 1.0, even if the kernel is bad.
-	final /= weights; 
+	final /= weights;
 
 	return final;
 }
@@ -60,20 +62,22 @@ float4 PSRotate(VertexInformation vtx) : TARGET {
 
 	// Calculate the actual Gaussian Blur
 	// 1. Sample the center immediately.
-	float kernel = kernelAt(0);
+	float kernel = kernelAt(0u);
 	weights += kernel;
 	float4 final = pImage.Sample(LinearClampSampler, vtx.uv) * kernel;
+
 	// 2. Then sample both + and - coordinates in one go to reduce code iterations.
-	for (uint step = 1; (step < pSize) && (step < MAX_SAMPLES); step++) {
+	for (uint step = 1u; (step < uint(pSize)) && (step < MAX_SAMPLES); step++) {
 		float offset = angstep * step;
 		kernel = kernelAt(step);
-		weights += kernel * 2;
+		weights += kernel * 2.;
 
 		final += pImage.Sample(LinearClampSampler, rotateAround(vtx.uv, pCenter, offset)) * kernel;
 		final += pImage.Sample(LinearClampSampler, rotateAround(vtx.uv, pCenter, -offset)) * kernel;
 	}
+
 	// 3. Ensure we always have a total of 1.0, even if the kernel is bad.
-	final /= weights; 
+	final /= weights;
 
 	return final;
 }
@@ -98,20 +102,22 @@ float4 PSZoom(VertexInformation vtx) : TARGET {
 
 	// Calculate the actual Gaussian Blur
 	// 1. Sample the center immediately.
-	float kernel = kernelAt(0);
+	float kernel = kernelAt(0u);
 	weights += kernel;
 	float4 final = pImage.Sample(LinearClampSampler, vtx.uv) * kernel;
+
 	// 2. Then sample both + and - coordinates in one go to reduce code iterations.
-	for (uint step = 1; (step < pSize) && (step < MAX_SAMPLES); step++) {
+	for (uint step = 1u; (step < uint(pSize)) && (step < MAX_SAMPLES); step++) {
 		float2 offset = dir * step * dist;
 		kernel = kernelAt(step);
-		weights += kernel * 2;
+		weights += kernel * 2.;
 
 		final += pImage.Sample(LinearClampSampler, vtx.uv + offset) * kernel;
 		final += pImage.Sample(LinearClampSampler, vtx.uv - offset) * kernel;
 	}
+
 	// 3. Ensure we always have a total of 1.0, even if the kernel is bad.
-	final /= weights; 
+	final /= weights;
 
 	return final;
 }


### PR DESCRIPTION
Fix a lot of mismatching or incorrect type usage only allowed by HLSL, which is not automatically handled by OBS's shader parser. Related to #576 
