### PR TITLE
New Shader Examples

### DIFF
--- a/data/examples/shaders/filter/blur-gaussian.effect
+++ b/data/examples/shaders/filter/blur-gaussian.effect
@@ -1,0 +1,196 @@
+// Copyright 2021 Michael Fabian Dirks <info@xaymar.com>
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+//    this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+// 3. Neither the name of the copyright holder nor the names of its contributors
+//    may be used to endorse or promote products derived from this software
+//    without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+// This shader is provided as a learning resource, a far more optimized version
+// is already part of StreamFX as the Blur filter.
+
+//------------------------------------------------------------------------------
+// Defines
+//------------------------------------------------------------------------------
+#define SAMPLE_RANGE 128
+#define BLUR_RANGE 32
+#define TO_RAD(x) (x *  0.017453292)
+#define TO_DEG(x) (x * 57.295779513)
+
+//------------------------------------------------------------------------------
+// Uniforms
+//------------------------------------------------------------------------------
+uniform float4x4 ViewProj<
+	bool automatic = true;
+>;
+
+uniform float4 ViewSize<
+	bool automatic = true;
+>;
+
+uniform texture2d InputA<
+	bool automatic = true;
+>;
+
+uniform int samples<
+	string name = "Samples";
+	string field_type = "slider";
+	int minimum = 0;
+	int maximum = SAMPLE_RANGE;
+	int step = 1;
+> = 8;
+
+uniform float size<
+	string name = "Size";
+	string field_type = "slider";
+	float minimum = 0.;
+	float maximum = BLUR_RANGE;
+	float step = .01;
+	float scale = 1.;
+> = 1.;
+
+uniform float direction<
+	string name = "Direction";
+	string field_type = "slider";
+	float minimum = -180.;
+	float maximum = 180.;
+	float step = .01;
+	float scale = 1.;
+> = 0.;
+
+//------------------------------------------------------------------------------
+// Structures
+//------------------------------------------------------------------------------
+struct VertexInformation {
+	float4 position : POSITION;
+	float4 texcoord0 : TEXCOORD0;
+};
+
+//------------------------------------------------------------------------------
+// Samplers
+//------------------------------------------------------------------------------
+sampler_state LinearClampSampler {
+	Filter    = Point;
+	AddressU  = Clamp;
+	AddressV  = Clamp;
+};
+
+//------------------------------------------------------------------------------
+// Functions
+//------------------------------------------------------------------------------
+VertexInformation DefaultVertexShader(VertexInformation vtx) {
+	vtx.position = mul(float4(vtx.position.xyz, 1.0), ViewProj);
+	return vtx;
+};
+
+bool is_equal(float a, float b) {
+	return (abs(a - b) <= .0001);
+}
+
+float gaussian(float x, float o /*, float u = 0*/)
+{
+	// u/µ can be simulated by subtracting that value from x.
+	float two_pi_sqroot = 2.506628274631000502415765284811;
+
+	if (is_equal(0., o)) {
+		return 1.0e24;
+	}
+
+	// g(x) = (1 / o√(2Π)) * e(-(1/2) * ((x-u)/o)²)
+	float left_e      = 1. / (o * two_pi_sqroot);
+	float mid_right_e = ((x /* - u*/) / o);
+	float right_e     = -0.5 * mid_right_e * mid_right_e;
+	float final       = left_e * exp(right_e);
+
+	return final;
+}
+
+//------------------------------------------------------------------------------
+// Technique: NxN
+//------------------------------------------------------------------------------
+float4 PSNxNtap(VertexInformation vtx) : TARGET {
+	vtx.texcoord0.xy += ViewSize.zw / 2.;
+
+	// Calculate the actual step to take.
+	float2 uv_step = ViewSize.zw;
+
+	float4 final = InputA.Sample(LinearClampSampler, vtx.texcoord0.xy) * gaussian(0., size);
+	float totals = gaussian(0., size);
+	for (uint xstep = 1; (xstep < samples) && (xstep < SAMPLE_RANGE); xstep++) {
+		float xkernel = gaussian(float(xstep), size);
+		for (uint ystep = 1; (ystep < samples) && (ystep < SAMPLE_RANGE); ystep++) {
+			float ykernel = gaussian(float(ystep), size);
+			float kernel = xkernel * ykernel;
+
+			totals += kernel * 4.;
+
+			float4 temp = float4(0, 0, 0, 0);
+			temp += InputA.Sample(LinearClampSampler, vtx.texcoord0.xy + float2(uv_step.x * xstep, uv_step.y * ystep));
+			temp += InputA.Sample(LinearClampSampler, vtx.texcoord0.xy + float2(uv_step.x * xstep, -uv_step.y * ystep));
+			temp += InputA.Sample(LinearClampSampler, vtx.texcoord0.xy + float2(-uv_step.x * xstep, uv_step.y * ystep));
+			temp += InputA.Sample(LinearClampSampler, vtx.texcoord0.xy + float2(-uv_step.x * xstep, -uv_step.y * ystep));
+
+			final += temp * kernel;
+		}
+	}
+	final /= totals;
+
+	return final;
+}
+
+technique NxNtap
+{
+	pass
+	{
+		vertex_shader = DefaultVertexShader(vtx);
+		pixel_shader  = PSNxNtap(vtx);
+	}
+}
+
+//------------------------------------------------------------------------------
+// Technique: Separable Directional
+//------------------------------------------------------------------------------
+float4 PSNtap(VertexInformation vtx) : TARGET {
+	// Calculate the actual step to take.
+	float2 uv_step = float2(cos(TO_RAD(direction)), sin(TO_RAD(direction))) * ViewSize.zw;
+
+	float kernel = gaussian(0., size);
+	float4 final = InputA.Sample(LinearClampSampler, vtx.texcoord0.xy) * kernel;
+	float weights = kernel;
+	for (uint step = 1; (step < samples) && (step < SAMPLE_RANGE); step++) {
+		kernel = gaussian(float(step), size);
+		final += InputA.Sample(LinearClampSampler, vtx.texcoord0.xy + uv_step * step) * kernel;
+		final += InputA.Sample(LinearClampSampler, vtx.texcoord0.xy - uv_step * step) * kernel;
+		weights += kernel * 2.;
+	}
+	final /= weights;
+
+	return final;
+}
+
+technique Ntap
+{
+	pass
+	{
+		vertex_shader = DefaultVertexShader(vtx);
+		pixel_shader  = PSNtap(vtx);
+	}
+}

--- a/data/examples/shaders/filter/colorize.effect
+++ b/data/examples/shaders/filter/colorize.effect
@@ -1,0 +1,159 @@
+// Copyright 2021 Michael Fabian Dirks <info@xaymar.com>
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+//    this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+// 3. Neither the name of the copyright holder nor the names of its contributors
+//    may be used to endorse or promote products derived from this software
+//    without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+//------------------------------------------------------------------------------
+// Uniforms
+//------------------------------------------------------------------------------
+uniform float4x4 ViewProj<
+	bool automatic = true;
+>;
+
+uniform texture2d InputA<
+	bool automatic = true;
+>;
+
+uniform float _100_Hue<
+	string name = "Hue";
+	string field_type = "slider";
+	float minimum = 0.;
+	float maximum = 360.;
+	float step = .01;
+	float scale = 0.00277777777777777777777777777778;
+> = 180.;
+uniform float _110_HueBlend<
+	string name = "Hue Blend";
+	string field_type = "slider";
+	float minimum = 0.;
+	float maximum = 100.;
+	float step = .01;
+	float scale = 0.01;
+> = 100.;
+
+uniform float _200_Saturation<
+	string name = "Saturation";
+	string field_type = "slider";
+	float minimum = 0.;
+	float maximum = 100.;
+	float step = .01;
+	float scale = 0.01;
+> = 100.;
+uniform float _210_SaturationBlend<
+	string name = "Saturation Blend";
+	string field_type = "slider";
+	float minimum = 0.;
+	float maximum = 100.;
+	float step = .01;
+	float scale = 0.01;
+> = 0.;
+
+uniform float _300_Value<
+	string name = "Value";
+	string field_type = "slider";
+	float minimum = 0.;
+	float maximum = 100.;
+	float step = .01;
+	float scale = 0.01;
+> = 100.;
+uniform float _310_ValueBlend<
+	string name = "Value Blend";
+	string field_type = "slider";
+	float minimum = 0.;
+	float maximum = 100.;
+	float step = .01;
+	float scale = 0.01;
+> = 0.;
+
+//------------------------------------------------------------------------------
+// Effect
+//------------------------------------------------------------------------------
+
+sampler_state linear_sampler {
+	Filter    = Linear;
+	AddressU  = Repeat;
+	AddressV  = Repeat;
+};
+
+struct VertFragData {
+	float4 pos : POSITION;
+	float2 uv  : TEXCOORD0;
+};
+
+VertFragData VSDefault(VertFragData vtx) {
+	vtx.pos = mul(float4(vtx.pos.xyz, 1.0), ViewProj);
+	return vtx;
+}
+
+// Adapted from http://lolengine.net/blog/2013/07/27/rgb-to-hsv-in-glsl
+
+#define RGB_HSV_FASTCONDITIONALMOVE
+
+float3 RGBtoHSV(float3 RGBA) {
+	const float4 K = float4(0.0, -1.0 / 3.0, 2.0 / 3.0, -1.0);
+	const float e = 1.0e-10;
+#ifdef RGB_HSV_FASTCONDITIONALMOVE
+	float4 p = RGBA.g < RGBA.b ? float4(RGBA.bg, K.wz) : float4(RGBA.gb, K.xy);
+	float4 q = RGBA.r < p.x    ? float4(p.xyw, RGBA.r) : float4(RGBA.r, p.yzx);
+#else
+	float4 p = lerp(float4(RGBA.bg, K.wz), float4(RGBA.gb, K.xy), step(RGBA.b, RGBA.g));
+	float4 q = lerp(float4(p.xyw, RGBA.r), float4(RGBA.r, p.yzx), step(p.x, RGBA.r));
+#endif
+	float d = q.x - min(q.w, q.y);
+	return float3(abs(q.z + (q.w - q.y) / (6.0 * d + e)), d / (q.x + e), q.x);
+}
+
+float4 RGBAtoHSVA(float4 RGBA) {
+	return float4(RGBtoHSV(RGBA.rgb), RGBA.a);
+}
+
+float3 HSVtoRGB(float3 HSVA) {
+	const float4 K = float4(1.0, 2.0 / 3.0, 1.0 / 3.0, 3.0);
+	float3 v = float3(0,0,0);
+	v = HSVA.z * lerp(K.xxx, clamp(abs(frac(HSVA.xxx + K.xyz) * 6.0 - K.www) - K.xxx, 0.0, 1.0), HSVA.y);
+	return v;
+}
+
+float4 HSVAtoRGBA(float4 HSVA) {
+	return float4(HSVtoRGB(HSVA.rgb), HSVA.a);
+}
+
+float4 PSVersion1(VertFragData vtx) : TARGET {
+	float4 rgba = InputA.Sample(linear_sampler, vtx.uv);
+	float4 hsva = RGBAtoHSVA(rgba);
+	hsva.r = lerp(hsva.r, _100_Hue, _110_HueBlend);
+	hsva.g = lerp(hsva.g, _200_Saturation, _210_SaturationBlend);
+	hsva.b = lerp(hsva.b, _300_Value, _310_ValueBlend);
+
+	return HSVAtoRGBA(hsva);
+};
+
+technique Version1
+{
+	pass
+	{
+		vertex_shader = VSDefault(vtx);
+		pixel_shader  = PSVersion1(vtx);
+	};
+};

--- a/data/examples/shaders/filter/posterize.effect
+++ b/data/examples/shaders/filter/posterize.effect
@@ -1,0 +1,323 @@
+// Copyright 2021 Michael Fabian Dirks <info@xaymar.com>
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+//    this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+// 3. Neither the name of the copyright holder nor the names of its contributors
+//    may be used to endorse or promote products derived from this software
+//    without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+//------------------------------------------------------------------------------
+// Uniforms
+//------------------------------------------------------------------------------
+uniform float4x4 ViewProj<
+	bool automatic = true;
+>;
+
+uniform float4 ViewSize<
+	bool automatic = true;
+>;
+
+uniform texture2d InputA<
+	bool automatic = true;
+>;
+
+uniform float4 _000_Levels<
+	string name = "Levels";
+	string field_type = "slider";
+	float4 minimum = {0., 0., 0., 0.};
+	float4 maximum = {1024., 1024., 1024., 100.};
+	float4 step = {1., 1., 1., .01};
+	float4 scale = {1., 1., 1., 100.};
+> = {1., 1., 1., 1.};
+
+uniform float4 _100_Offset<
+	string name = "Bias";
+	string field_type = "slider";
+	float4 minimum = {-100., -100., -100., -100.};
+	float4 maximum = {100., 100., 100., 100.};
+	float4 step = {.01, .01, .01, .01};
+	float4 scale = {.005, .005, .005, .005};
+>;
+
+uniform bool _200_PassThroughAlpha<
+	string name = "Alpha Pass Through";
+> = true;
+
+//------------------------------------------------------------------------------
+// Structs
+//------------------------------------------------------------------------------
+struct VertFragData {
+	float4 pos : POSITION;
+	float2 uv  : TEXCOORD0;
+};
+
+//------------------------------------------------------------------------------
+// Samplers
+//------------------------------------------------------------------------------
+sampler_state def_sampler {
+	Filter    = Point;
+	AddressU  = Repeat;
+	AddressV  = Repeat;
+};
+
+//------------------------------------------------------------------------------
+// Functionality
+//------------------------------------------------------------------------------
+VertFragData VSDefault(VertFragData vtx) {
+	vtx.pos = mul(float4(vtx.pos.xyz, 1.0), ViewProj);
+	return vtx;
+};
+
+//------------------------------------------------------------------------------
+// Technique - RGB
+//------------------------------------------------------------------------------
+float4 PSRGB(VertFragData vtx) : TARGET {
+	float4 rgba = InputA.Sample(def_sampler, vtx.uv);
+
+	float4 polar = (round(rgba * _000_Levels - _100_Offset) + _100_Offset) / _000_Levels;
+
+	if (_200_PassThroughAlpha)
+		polar.a = rgba.a;
+
+	return polar;
+};
+
+technique RGB
+{
+	pass
+	{
+		vertex_shader = VSDefault(vtx);
+		pixel_shader  = PSRGB(vtx);
+	};
+};
+
+//------------------------------------------------------------------------------
+// Technique - YUV
+//------------------------------------------------------------------------------
+#define RGB_YUV_709 float3x3( 0.21260,  0.71520,  0.07220,\
+                             -0.11457, -0.38543,  0.50000,\
+                              0.50000, -0.45415, -0.04585)
+#define YUV_709_RGB float3x3( 1.00000,  0.00000,  1.57480,\
+                              1.00000, -0.18732, -0.46812,\
+                              1.00000,  1.85560,  0.00000)
+
+float3 RGBtoYUV(float3 rgb, float3x3 m) {
+	return mul(m, rgb) + float3(0, .5, .5);
+}
+
+float4 RGBAtoYUVA(float4 rgba, float3x3 m) {
+	return float4(RGBtoYUV(rgba.rgb, m), rgba.a);
+}
+
+float3 YUVtoRGB(float3 yuv, float3x3 m) {
+	return mul(m, yuv - float3(0, .5, .5));
+}
+
+float4 YUVAtoRGBA(float4 yuva, float3x3 m) {
+	return float4(YUVtoRGB(yuva.rgb, m), yuva.a);
+}
+
+float4 PSYUV(VertFragData vtx) : TARGET {
+	float4 rgba = InputA.Sample(def_sampler, vtx.uv);
+	float4 yuva = RGBAtoYUVA(rgba, YUV_709_RGB);
+
+	float4 polar = round(yuva * _000_Levels + _100_Offset) / _000_Levels;
+
+	if (_200_PassThroughAlpha)
+		polar.a = rgba.a;
+
+	float4 final = YUVAtoRGBA(polar, RGB_YUV_709);
+	return final;
+};
+
+technique YUV
+{
+	pass
+	{
+		vertex_shader = VSDefault(vtx);
+		pixel_shader  = PSYUV(vtx);
+	};
+};
+
+//------------------------------------------------------------------------------
+// Technique - HSV
+//------------------------------------------------------------------------------
+// Adapted from http://lolengine.net/blog/2013/07/27/rgb-to-hsv-in-glsl
+
+#define RGB_HSV_FASTCONDITIONALMOVE
+
+float3 RGBtoHSV(float3 RGBA) {
+	const float4 K = float4(0.0, -1.0 / 3.0, 2.0 / 3.0, -1.0);
+	const float e = 1.0e-10;
+#ifdef RGB_HSV_FASTCONDITIONALMOVE
+	float4 p = RGBA.g < RGBA.b ? float4(RGBA.bg, K.wz) : float4(RGBA.gb, K.xy);
+	float4 q = RGBA.r < p.x    ? float4(p.xyw, RGBA.r) : float4(RGBA.r, p.yzx);
+#else
+	float4 p = lerp(float4(RGBA.bg, K.wz), float4(RGBA.gb, K.xy), step(RGBA.b, RGBA.g));
+	float4 q = lerp(float4(p.xyw, RGBA.r), float4(RGBA.r, p.yzx), step(p.x, RGBA.r));
+#endif
+	float d = q.x - min(q.w, q.y);
+	return float3(abs(q.z + (q.w - q.y) / (6.0 * d + e)), d / (q.x + e), q.x);
+}
+
+float4 RGBAtoHSVA(float4 RGBA) {
+	return float4(RGBtoHSV(RGBA.rgb), RGBA.a);
+}
+
+float3 HSVtoRGB(float3 HSVA) {
+	const float4 K = float4(1.0, 2.0 / 3.0, 1.0 / 3.0, 3.0);
+	float3 v = float3(0,0,0);
+	v = HSVA.z * lerp(K.xxx, clamp(abs(frac(HSVA.xxx + K.xyz) * 6.0 - K.www) - K.xxx, 0.0, 1.0), HSVA.y);
+	return v;
+}
+
+float4 HSVAtoRGBA(float4 HSVA) {
+	return float4(HSVtoRGB(HSVA.rgb), HSVA.a);
+}
+
+float4 PSHSV(VertFragData vtx) : TARGET {
+	float4 rgba = InputA.Sample(def_sampler, vtx.uv);
+	float4 hsva = RGBAtoHSVA(rgba);
+
+	float4 polar = round(hsva * _000_Levels + _100_Offset) / _000_Levels;
+	polar = clamp(polar, float4(-1., 0., 0., 0.), float4(2., 1., 1., 1.));
+
+	if (_200_PassThroughAlpha)
+		polar.a = rgba.a;
+
+	float4 final = HSVAtoRGBA(polar);
+	return final;
+};
+
+technique HSV
+{
+	pass
+	{
+		vertex_shader = VSDefault(vtx);
+		pixel_shader  = PSHSV(vtx);
+	};
+};
+
+//------------------------------------------------------------------------------
+// Technique - CIE
+//------------------------------------------------------------------------------
+// XYZ <-> RGB
+float4 RGBtoXYZ( float4 c ) {
+    float3 tmp;
+    tmp.x = ( c.r > 0.04045 ) ? pow( ( c.r + 0.055 ) / 1.055, 2.4 ) : c.r / 12.92;
+    tmp.y = ( c.g > 0.04045 ) ? pow( ( c.g + 0.055 ) / 1.055, 2.4 ) : c.g / 12.92,
+    tmp.z = ( c.b > 0.04045 ) ? pow( ( c.b + 0.055 ) / 1.055, 2.4 ) : c.b / 12.92;
+    const float3x3 mat = float3x3(
+		0.4124, 0.3576, 0.1805,
+        0.2126, 0.7152, 0.0722,
+        0.0193, 0.1192, 0.9505
+	);
+	float3 r = 100.0 * mul(tmp, mat);
+    return float4(r.r, r.g, r.b, c.a);
+}
+
+float4 XYZtoRGB( float4 c ) {
+	const float3x3 mat = float3x3(
+        3.2406, -1.5372, -0.4986,
+        -0.9689, 1.8758, 0.0415,
+        0.0557, -0.2040, 1.0570
+	);
+    float3 v = mul(c.rgb / 100.0, mat);
+    float4 r;
+    r.x = ( v.r > 0.0031308 ) ? (( 1.055 * pow( v.r, ( 1.0 / 2.4 ))) - 0.055 ) : 12.92 * v.r;
+    r.y = ( v.g > 0.0031308 ) ? (( 1.055 * pow( v.g, ( 1.0 / 2.4 ))) - 0.055 ) : 12.92 * v.g;
+    r.z = ( v.b > 0.0031308 ) ? (( 1.055 * pow( v.b, ( 1.0 / 2.4 ))) - 0.055 ) : 12.92 * v.b;
+	r.a = c.a;
+    return r;
+}
+
+// XYZ <-> L*a*b
+float4 XYZtoLAB( float4 c ) {
+    float3 n = c.rgb / float3(95.047, 100, 108.883);
+    float3 v;
+    v.x = ( n.x > 0.008856 ) ? pow( n.x, 1.0 / 3.0 ) : ( 7.787 * n.x ) + ( 16.0 / 116.0 );
+    v.y = ( n.y > 0.008856 ) ? pow( n.y, 1.0 / 3.0 ) : ( 7.787 * n.y ) + ( 16.0 / 116.0 );
+    v.z = ( n.z > 0.008856 ) ? pow( n.z, 1.0 / 3.0 ) : ( 7.787 * n.z ) + ( 16.0 / 116.0 );
+    return float4(
+		( 116.0 * v.y ) - 16.0,
+		500.0 * ( v.x - v.y ),
+		200.0 * ( v.y - v.z ),
+		c.a
+	);
+}
+
+float4 LABtoXYZ( float4 c ) {
+    float fy = ( c.x + 16.0 ) / 116.0;
+    float fx = c.y / 500.0 + fy;
+    float fz = fy - c.z / 200.0;
+    return float4(
+         95.047 * (( fx > 0.206897 ) ? fx * fx * fx : ( fx - 16.0 / 116.0 ) / 7.787),
+        100.000 * (( fy > 0.206897 ) ? fy * fy * fy : ( fy - 16.0 / 116.0 ) / 7.787),
+        108.883 * (( fz > 0.206897 ) ? fz * fz * fz : ( fz - 16.0 / 116.0 ) / 7.787),
+		c.a
+    );
+}
+
+// L*a*b <-> RGB
+float4 RGBtoLAB( float4 c ) {
+    float4 lab = XYZtoLAB(RGBtoXYZ(c));
+    return float4(
+		lab.x / 100.0,
+		0.5 + 0.5 * ( lab.y / 127.0 ),
+		0.5 + 0.5 * ( lab.z / 127.0 ),
+		lab.a
+	);
+}
+
+float4 LABtoRGB( float4 c ) {
+    return XYZtoRGB(
+		LABtoXYZ(
+			float4(
+				100.0 * c.x,
+				2.0 * 127.0 * (c.y - 0.5),
+				2.0 * 127.0 * (c.z - 0.5),
+				c.a
+			)
+		)
+	);
+}
+
+float4 PSLAB(VertFragData vtx) : TARGET {
+	float4 rgba = InputA.Sample(def_sampler, vtx.uv);
+	float4 value = RGBtoLAB(rgba);
+
+	value = round(value * _000_Levels + _100_Offset) / _000_Levels;
+	//polar = clamp(polar, float4(-1., 0., 0., 0.), float4(2., 1., 1., 1.));
+
+	if (_200_PassThroughAlpha)
+		value.a = rgba.a;
+
+	return LABtoRGB(value);
+};
+
+technique LAB
+{
+	pass
+	{
+		vertex_shader = VSDefault(vtx);
+		pixel_shader  = PSLAB(vtx);
+	};
+};

--- a/data/examples/shaders/filter/repeat.effect
+++ b/data/examples/shaders/filter/repeat.effect
@@ -1,0 +1,86 @@
+// Copyright 2021 Michael Fabian Dirks <info@xaymar.com>
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+//    this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+// 3. Neither the name of the copyright holder nor the names of its contributors
+//    may be used to endorse or promote products derived from this software
+//    without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+//------------------------------------------------------------------------------
+// Uniforms
+//------------------------------------------------------------------------------
+uniform float4x4 ViewProj<
+	bool automatic = true;
+>;
+
+uniform float4 ViewSize<
+	bool automatic = true;
+>;
+
+uniform texture2d InputA<
+	bool automatic = true;
+>;
+
+uniform int2 Repeats<
+	string name = "Repeats";
+	int2 minimum = {1, 1};
+	int2 maximum = {10000, 10000};
+	int2 step = {1, 1};
+> = {4, 4};
+
+//------------------------------------------------------------------------------
+// Structs
+//------------------------------------------------------------------------------
+struct VertFragData {
+	float4 pos : POSITION;
+	float2 uv  : TEXCOORD0;
+};
+
+//------------------------------------------------------------------------------
+// Samplers
+//------------------------------------------------------------------------------
+sampler_state def_sampler {
+	Filter    = Point;
+	AddressU  = Repeat;
+	AddressV  = Repeat;
+};
+
+//------------------------------------------------------------------------------
+// Functionality
+//------------------------------------------------------------------------------
+VertFragData VSDefault(VertFragData vtx) {
+	vtx.pos = mul(float4(vtx.pos.xyz, 1.0), ViewProj);
+	vtx.uv *= Repeats.xy;
+	return vtx;
+};
+
+float4 PSDefault(VertFragData vtx) : TARGET {
+	return InputA.Sample(def_sampler, vtx.uv);
+}
+
+technique Draw
+{
+	pass
+	{
+		vertex_shader = VSDefault(vtx);
+		pixel_shader  = PSDefault(vtx);
+	}
+}

--- a/data/examples/shaders/filter/vignette.effect
+++ b/data/examples/shaders/filter/vignette.effect
@@ -1,0 +1,135 @@
+// Copyright 2021 Michael Fabian Dirks <info@xaymar.com>
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+//    this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+// 3. Neither the name of the copyright holder nor the names of its contributors
+//    may be used to endorse or promote products derived from this software
+//    without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+// Always provided by OBS
+uniform float4x4 ViewProj<
+	bool automatic = true;
+	string name = "View Projection Matrix";
+>;
+
+// Provided by Stream Effects
+uniform texture2d InputA<
+	bool automatic = true;
+>;
+
+uniform float _00_vignette_area<
+	string name = "Vignetting Area";
+	string field_type = "slider";
+	float minimum = 0.;
+	float maximum = 100.;
+	float step = 0.01;
+	float scale = 0.01;
+> = 50.0;
+
+uniform float4 _01_vignette_color<
+	string name = "Vignette Color";
+	string field_type = "slider";
+	float4 minimum = {0., 0., 0., 0.};
+	float4 maximum = {100., 100., 100., 100.};
+	float4 step = {0.01, 0.01, 0.01, 0.01};
+	float4 scale = {0.01, 0.01, 0.01, 0.01};
+> = {0., 0., 0., 0.};
+
+uniform float _02_vignette_strength<
+	string name = "Vignette Strength";
+	string field_type = "slider";
+	float minimum = 0.;
+	float maximum = 100.;
+	float step = 0.01;
+	float scale = 0.01;
+> = 100.0;
+
+#define PI		3.1415926f
+#define TwoPI	6.2831853f
+#define HalfPI	1.5707963f
+
+// ---------- Shader Code
+sampler_state def_sampler {
+	AddressU  = Clamp;
+	AddressV  = Clamp;
+	Filter    = Linear;
+};
+
+struct VertData {
+	float4 pos : POSITION;
+	float2 uv  : TEXCOORD0;
+};
+
+VertData VSDefault(VertData v_in) {
+	VertData vert_out;
+	vert_out.pos = mul(float4(v_in.pos.xyz, 1.0), ViewProj);
+	vert_out.uv  = v_in.uv;
+	return vert_out;
+}
+
+float4 PSDefault(VertData v_in) : TARGET {
+    static const float2 center = float2(.5, .5);
+    float4 smp = InputA.Sample(def_sampler, v_in.uv);
+	float borderFade = clamp(((1. - distance(v_in.uv, center)) - (_00_vignette_area - .5)), 0., 1.);
+
+    float4 vignette_color = _01_vignette_color;
+	return lerp(smp, vignette_color, (1. - borderFade) / max(1. - _02_vignette_strength, 0.0001));
+}
+
+technique Draw
+{
+	pass
+	{
+		vertex_shader = VSDefault(v_in);
+		pixel_shader  = PSDefault(v_in);
+	}
+}
+
+float4 PSRectangle(VertData v_in) : TARGET {
+    static const float2 center = float2(.5, .5);
+    float4 smp = InputA.Sample(def_sampler, v_in.uv);
+
+    if (_00_vignette_area < 0.01)
+        return smp;
+
+	float2 borderArea = center * _00_vignette_area;
+	float2 borderDistance = center;
+    borderDistance -= abs(v_in.uv - center);
+    borderDistance /= center;
+    borderDistance -= center * _00_vignette_area;
+    borderDistance = min(borderDistance, 0);
+    borderDistance += borderArea;
+    borderDistance /= borderArea;
+
+	// Now apply a modifier so that we only get the border area.
+	float borderFade = sin(borderDistance.x * HalfPI) * sin(borderDistance.y * HalfPI);
+
+	return lerp(smp, _01_vignette_color, (1. - borderFade) * _02_vignette_strength);
+}
+
+technique Rectangle
+{
+	pass
+	{
+		vertex_shader = VSDefault(v_in);
+		pixel_shader  = PSRectangle(v_in);
+	}
+}

--- a/data/examples/shaders/transition/spin-blur.effect
+++ b/data/examples/shaders/transition/spin-blur.effect
@@ -1,0 +1,340 @@
+// Copyright 2021 Michael Fabian Dirks <info@xaymar.com>
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+//    this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+// 3. Neither the name of the copyright holder nor the names of its contributors
+//    may be used to endorse or promote products derived from this software
+//    without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+//------------------------------------------------------------------------------
+// Configuration
+//------------------------------------------------------------------------------
+#define IS_TRANSITION
+
+//------------------------------------------------------------------------------
+// Defines
+//------------------------------------------------------------------------------
+// Variations of PI/TAU
+#define PI   3.141592653
+#define TAU  6.283185307
+#define PIm2 6.283185307
+#define PIb2 1.570796326
+#define PIb4 0.785398163
+
+// Phi/Φ = Golden Ratio
+#define PHI 1.61803398874989484820459
+
+// e (Eulers Constant)
+#define EULERS_CONSTANT 2,7182818284590452353602874713527
+
+// Degrees <-> Radians Conversion
+#define TO_RAD(x) (x *  0.017453292)
+#define TO_DEG(x) (x * 57.295779513)
+
+//------------------------------------------------------------------------------
+// Uniforms
+//------------------------------------------------------------------------------
+uniform float4x4 ViewProj<
+	bool automatic = true;
+>;
+
+uniform float4 Time<
+	bool automatic = true;
+>;
+
+uniform float4 ViewSize<
+	bool automatic = true;
+>;
+
+// Filter Support
+#ifdef IS_FILTER
+uniform texture2d InputA<
+	bool automatic = true;
+>;
+#endif
+
+// Transition Support
+#ifdef IS_TRANSITION
+uniform texture2d InputA<
+	bool automatic = true;
+>;
+
+uniform texture2d InputB<
+	bool automatic = true;
+>;
+
+uniform float TransitionTime<
+	bool automatic = true;
+>;
+
+uniform int2 TransitionSize<
+	bool automatic = true;
+>;
+#endif
+
+uniform int RandomSeed<
+	bool automatic = true;
+>;
+
+uniform float4x4 Random<
+	bool automatic = true;
+>;
+
+//------------------------------------------------------------------------------
+// Structures
+//------------------------------------------------------------------------------
+struct VertexInformation {
+	float4 position : POSITION;
+	float4 texcoord0 : TEXCOORD0;
+};
+
+//------------------------------------------------------------------------------
+// Samplers
+//------------------------------------------------------------------------------
+sampler_state PointRepeatSampler {
+	Filter    = Point;
+	AddressU  = Repeat;
+	AddressV  = Repeat;
+};
+sampler_state LinearRepeatSampler {
+	Filter    = Linear;
+	AddressU  = Repeat;
+	AddressV  = Repeat;
+};
+
+sampler_state PointMirrorSampler {
+	Filter    = Point;
+	AddressU  = Mirror;
+	AddressV  = Mirror;
+};
+sampler_state LinearMirrorSampler {
+	Filter    = Linear;
+	AddressU  = Mirror;
+	AddressV  = Mirror;
+};
+
+sampler_state PointClampSampler {
+	Filter    = Point;
+	AddressU  = Clamp;
+	AddressV  = Clamp;
+};
+sampler_state LinearClampSampler {
+	Filter    = Linear;
+	AddressU  = Clamp;
+	AddressV  = Clamp;
+};
+
+//------------------------------------------------------------------------------
+// Functions
+//------------------------------------------------------------------------------
+VertexInformation DefaultVertexShader(VertexInformation vtx) {
+	vtx.position = mul(float4(vtx.position.xyz, 1.0), ViewProj);
+	return vtx;
+};
+
+float2 rotate2d(float2 v, float angle) {
+	float s = sin(angle);
+	float c = cos(angle);
+	float2x2 m = float2x2(c, -s, s, c);
+	return mul(m, v);
+};
+
+//------------------------------------------------------------------------------
+// Options
+//------------------------------------------------------------------------------
+
+uniform float2 _400_Offset<
+	string name = "Rotation Center";
+	string field_type = "slider";
+	string suffix = "%";
+	float2 minimum = {-50., -50.};
+	float2 maximum = {50., 50.};
+	float2 scale = {.01, .01};
+	float2 step = {.01, .01};
+> = {0., 0.};
+
+uniform float _500_Rotation<
+	string name = "Rotation";
+	string field_type = "slider";
+	string suffix = "°";
+	float minimum = -180.;
+	float maximum =  180.;
+	float scale = -1.;
+	float step = .01;
+> = 90.;
+
+uniform float _600_BlurRotation<
+	string name = "Blur Rotation";
+	string field_type = "slider";
+	string suffix = "°";
+	float minimum = -90.;
+	float maximum =  90.;
+	float scale = 1.;
+	float step = .01;
+> = 30.;
+
+uniform float _700_TransitionRange<
+	string name = "Transition Range";
+	string field_type = "slider";
+	string suffix = "%";
+	float minimum = 0.;
+	float maximum = 100.;
+	float scale = .01;
+	float step = .01;
+> = 10.;
+
+uniform int _900_MaximumBlurSamples<
+	string name = "Max. Blur Samples";
+	string description = "The maximum of samples to use for the Blur effect. Higher number looks nicer, but has way higher GPU usage.";
+	string field_type = "slider";
+	string suffix = "";
+	int minimum = 4;
+	int maximum = 128;
+	int scale = 1;
+	int step = 1;
+> = 8;
+
+uniform bool _990_MirrorInsteadOfRepeat<
+	string name = "Mirror instead of Repeat";
+> = true;
+
+//------------------------------------------------------------------------------
+// Effect
+//------------------------------------------------------------------------------
+// Edge is 50% progress
+// Rotates n° forward/backward, then switches to B, then rotates back to zero in the other direction.
+// While rotated, blurs around the same axis.
+// Starts slow, speeds up to 100%, then slows down again. Looks like sine curve.
+
+float2 uv_to_xy(float2 uv) {
+	return ((uv - float2(.5, .5)) + _400_Offset) * TransitionSize.xy;
+}
+
+float2 xy_to_uv(float2 xy) {
+	return ((xy / TransitionSize.xy) - _400_Offset) + float2(.5, .5);
+}
+
+float4 SampleTexture(texture2d tex, float2 uv) {
+	if (_990_MirrorInsteadOfRepeat) {
+		return tex.Sample(LinearMirrorSampler, uv);
+	} else {
+		return tex.Sample(LinearRepeatSampler, uv);
+	}
+}
+
+float4 sample_with_blur(texture2d tex, float2 xy, float max_angle, uint max_steps) {
+	float angle_step = max_angle / float(max_steps);
+
+	float4 final = SampleTexture(tex, xy_to_uv(xy));
+	for (uint step = 1; step <= max_steps; step++) {
+		float angle = angle_step * float(step);
+		float2 xy_p = rotate2d(xy, TO_RAD(angle));
+		float2 xy_n = rotate2d(xy, TO_RAD(-angle));
+
+		final += SampleTexture(tex, xy_to_uv(xy_p));
+		final += SampleTexture(tex, xy_to_uv(xy_n));
+	}
+	final /= (max_steps * 2u + 1u);
+
+	return final;
+}
+
+float4 DefaultPixelShader(VertexInformation vtx) : TARGET {
+	// Precalculate some important information.
+	float2 uv = vtx.texcoord0.xy;
+	// - UV offset towards the "center".
+	float2 uv_offset = ((uv - float2(.5, .5)) + _400_Offset);
+	float2 xy = uv_to_xy(uv);
+	// - Distance to the "center" from the offset coordinates.
+	float distance_to_center = distance(uv_offset, float2(.0, 0.));
+	// - Maximum Blur Angle
+	float max_blur_angle = _600_BlurRotation;
+	max_blur_angle *= sin(distance_to_center * PIb2);
+	max_blur_angle *= cos((TransitionTime * 2. + 1. ) * PI) * .5 + .5;
+	// - Maximum number of samples for blurring.
+	uint max_blur_samples = uint(_900_MaximumBlurSamples); // TODO: Calculate this value?
+
+	// Calculate the angle of the effect, this goes to _500_Rotation over 0-50%,
+	// then goes back in reverse in order to give the illusion of a continuous
+	// motion.
+	float angle_a = sin((TransitionTime * 2.) * PIb2 - PIb2) * _500_Rotation + _500_Rotation;
+	float angle_b = sin((TransitionTime * 2. - 1.) * PIb2) * _500_Rotation - _500_Rotation ;
+
+	// Generate the rotated XY position for sampling.
+	float2 xy_a = rotate2d(xy, TO_RAD(angle_a));
+	float2 xy_b = rotate2d(xy, TO_RAD(angle_b));
+
+	// Calculate the weight of A and B.
+	// - Convert the transition point to a range from -1 to 1.
+	float weight_a = (TransitionTime - .5) * 2.; // We don't actually want this range, but it is easier to work with.
+	// - Offset it by the transition range.
+	weight_a += _700_TransitionRange;
+	// - Divide it by the transition range times two.
+	weight_a /= _700_TransitionRange * 2.;
+	// - Clamp it back to a range from 0 to 1.
+	weight_a = 1. - (cos((clamp(weight_a, 0., 1.) + 1.) * PI) * .5 + .5); // Curve
+	//weight_a = 1. - clamp(weight_a, 0., 1.); // Alternative linear
+	// - The weight for the B side is the one-minus of the A side.
+	float weight_b = 1. - weight_a;
+
+	// Store some immediate information.
+	float4 color_a = float4(0., 0., 0., 0.);
+	float4 color_b = float4(0., 0., 0., 0.);
+
+	// Only sample A and B if they are needed.
+	if (weight_a >= 0.001) {
+		color_a = sample_with_blur(InputA, xy_a, max_blur_angle, max_blur_samples);
+	}
+	if (weight_b >= 0.001) {
+		color_b = sample_with_blur(InputB, xy_b, max_blur_angle, max_blur_samples);
+	}
+
+	// Return a blended color.
+	return lerp(color_a, color_b, weight_b);
+};
+
+technique Draw
+{
+	pass
+	{
+		vertex_shader = DefaultVertexShader(vtx);
+		pixel_shader  = DefaultPixelShader(vtx);
+	};
+};
+
+technique Version1_Normal
+{
+	pass
+	{
+		vertex_shader = DefaultVertexShader(vtx);
+		pixel_shader  = DefaultPixelShader(vtx);
+	};
+};
+
+
+technique Version1_Mirror
+{
+	pass
+	{
+		vertex_shader = DefaultVertexShader(vtx);
+		pixel_shader  = DefaultPixelShader(vtx);
+	};
+};


### PR DESCRIPTION
### Explain the Pull Request
Adds several example shaders as learning resources for people:

- **Gaussian Blur:** A reference implementation used to fix Gaussian Blur in the plugin itself, correct to a high degree.
- **Spin Blur:** Weird spin transition effect that people pay for.
- **Posterize:** Your classic posterize effect.
- **Repeat:** Your classic repeating effect. repeating effect. repeating effect.
- **Vignette:** Barebone vignette implementation.
- **Colorize:** Re-color any footage with the specific color.

### Why is this necessary?
Users find it difficult to read channel names on Discord.

### Checklist
- [x] I will become the maintainer for this part of code.
- [ ] I have tested this code on all supported Platforms.

### Related Issues
<!-- Is this PR related to another PR or Issue? List them here. -->
<!-- - #0000 Name of Issue -->
<!-- - #0001 Name of Issue -->
