### PR TITLE
Add additional shaders

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,9 @@
 * @xaymar
 /data/examples/filter/rounded-rect.effect @carlosbaraza
+/data/examples/shaders/filter/bulge_pinch.effect @radeghast-ffxiv
+/data/examples/shaders/filter/swirl.effect @radeghast-ffxiv
+/data/examples/shaders/filter/wave.effect @radeghast-ffxiv
+/data/examples/shaders/filter/zigzag.effect @radeghast-ffxiv
 
 # Security critical owners
 /.github @xaymar

--- a/data/examples/shaders/filter/bulge_pinch.effect
+++ b/data/examples/shaders/filter/bulge_pinch.effect
@@ -1,0 +1,155 @@
+// Copyright 2021 Radegast Stravinsky <radegast.ffxiv@gmail.com>
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+//	this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//	this list of conditions and the following disclaimer in the documentation
+//	and/or other materials provided with the distribution.
+// 3. Neither the name of the copyright holder nor the names of its contributors
+//	may be used to endorse or promote products derived from this software
+//	without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#include "../base.effect"
+//-----------------------------------------------------------------------------
+// Uniforms
+//-----------------------------------------------------------------------------
+
+// Provided by StreamFX
+uniform float4 Time<
+	bool automatic = true;
+>;
+uniform float4 ViewSize<
+	bool automatic = true;
+>;
+uniform texture2d InputA<
+	bool automatic = true;
+>;
+
+uniform float radius<
+	string name = "Radius";
+	string description = "The radius of the effect.";
+	string field_type = "slider";
+	float step = 0.01;
+	float minimum = 0.0;
+	float maximum = 1.0;
+> = 0.5;
+
+uniform float2 coordinates<
+	string name = "Coordinates (X, Y)";
+	string description = "Determines the center of the effect.";
+	string field_type = "slider";
+	float2 step = {0.01, 0.01};
+	float2 minimum = {0.0, 0.0};
+	float2 maximum = {1.0, 1.0};
+> = {0.5, 0.5};
+
+uniform float magnitude<
+	string name = "Magnitude";
+	string description = "The magnitude of the distortion.";
+	string field_type = "slider";
+	float minimum = -1.0;
+	float maximum = 1.0;
+> = 1.0;
+
+uniform float tension<
+	string name = "Tension";
+	string description = "Controls how rapidly the distortion reaches the maximum value.";
+	string field_type = "slider";
+	float step = 0.01;
+	float minimum = 0.0;
+	float maximum = 10.0;
+> = 1.0;
+
+uniform float aspect_ratio<
+	string name = "Aspect Ratio";
+	string description = "Adjusts the aspect ratio for the associated distortion.";
+	string field_type = "slider";
+	float step = 0.01;
+	float minimum = -1;
+	float maximum = 1;
+> = 0.0;
+
+uniform bool animate<
+	string name = "Animate";
+	string description = "Animates the effect, making it alternate between pinching and bulging.";
+> = false;
+
+//-----------------------------------------------------------------------------
+// Structs
+//-----------------------------------------------------------------------------
+struct VertexData {
+	float4 pos : POSITION;
+	float2 uv : TEXCOORD0;
+};
+
+//-----------------------------------------------------------------------------
+// Samplers
+//-----------------------------------------------------------------------------
+sampler_state texture_sampler {
+	Filter    = Linear;
+	AddressU  = Mirror;
+	AddressV  = Mirror;
+};
+
+//-----------------------------------------------------------------------------
+// Functions
+//-----------------------------------------------------------------------------
+float4 PSBulgePinch(VertexData vtx) : TARGET {
+	const float ar_raw = 1. * ViewSize.y / ViewSize.x;
+    float ar = lerp(ar_raw, 1, aspect_ratio);
+
+    float2 center = coordinates/2.0;
+    float2 tc = vtx.uv - center;
+
+    float4 color;
+
+    center.x /= ar;
+    tc.x /= ar;
+
+    float dist = distance(tc, center);
+    float anim_mag = (animate == 1 ? magnitude * sin(Time.x) : magnitude);
+    if (dist < radius && anim_mag != 0)
+    {
+        float tension_radius = lerp(dist, radius, tension);
+        float percent = (dist)/tension_radius;
+        if(anim_mag > 0)
+            tc = (tc-center) * lerp(1.0, smoothstep(0.0, tension_radius/dist, percent), anim_mag * 0.75);
+        else
+            tc = (tc-center) * lerp(1.0, pow(abs(percent), 1.0 + anim_mag * 0.75) * tension_radius/dist, 1.0 - percent);
+
+        tc += (2*center);
+        tc.x *= ar;
+
+        color = InputA.Sample(texture_sampler, tc);
+    }
+    else {
+        color = InputA.Sample(texture_sampler, vtx.uv);
+    }
+
+
+
+    return color;
+}
+
+technique BulgePinch {
+	pass
+	{
+		vertex_shader = DefaultVertexShader(vtx);
+		pixel_shader = PSBulgePinch(vtx);
+	}
+}

--- a/data/examples/shaders/filter/wave.effect
+++ b/data/examples/shaders/filter/wave.effect
@@ -1,0 +1,196 @@
+// Copyright 2021 Radegast Stravinsky <radegast.ffxiv@gmail.com>
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+//	this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//	this list of conditions and the following disclaimer in the documentation
+//	and/or other materials provided with the distribution.
+// 3. Neither the name of the copyright holder nor the names of its contributors
+//	may be used to endorse or promote products derived from this software
+//	without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#include "../base.effect"
+
+//-----------------------------------------------------------------------------
+// Uniforms
+//-----------------------------------------------------------------------------
+
+// Provided by StreamFX
+uniform float4 Time<
+	bool automatic = true;
+>;
+uniform float4 ViewSize<
+	bool automatic = true;
+>;
+uniform texture2d InputA<
+	bool automatic = true;
+>;
+
+uniform float magnitude<
+	string name = "Magnitude";
+	string description = "The magnitude of the distortion.";
+	string field_type = "slider";
+	float minimum = 0.0;
+	float maximum = 10.0;
+> = 1.0;
+
+uniform float angle<
+    string name = "Angle";
+    string description = "The amount of oscillation in the image.";
+    string field_type = "slider";
+    float minimum = -1800.0;
+    float maximum = 1800.0;
+> = 90.0;
+
+uniform float period<
+	string name = "Period";
+	string description = "The frequency at which the wave oscillation occurs.";
+	string field_type = "slider";
+	float minimum = 0.0;
+	float maximum = 10.0;
+> = 0.5;
+
+uniform float phase<
+    string name = "Phase";
+    string description = "Adjusts the phase of the wave.";
+	string field_type = "slider";
+	float minimum = -1.0;
+	float maximum = 1.0;
+> = 0.0;
+
+uniform float amplitude<
+	string name = "Amplitude";
+	string description = "Adjusts the amplitude of the wave.";
+	string field_type = "slider";
+	float minimum = -1.0;
+	float maximum = 1.0;
+> = 0.25;
+
+uniform int wave_type<
+	string name = "Wave Type";
+	string description = "The wave distortion type to use.";
+	string field_type = "enum";
+	// Enumeration
+	int enum = 2;
+	int enum_0 = 0;
+	string enum_0_name = "X/X";
+	int enum_1 = 1;
+	string enum_1_name = "X/Y";
+> = 1;
+
+uniform int animate<
+	string name = "Animate By";
+	string description = "Animates the wave distortion by one of the parameters.";
+	string field_type = "enum";
+	// Enumeration
+	int enum = 4;
+	int enum_0 = 0;
+	string enum_0_name = "None";
+	int enum_1 = 1;
+	string enum_1_name = "Amplitude";
+	int enum_2 = 2;
+	string enum_2_name = "Phase";
+	int enum_3 = 3;
+	string enum_3_name = "Angle";
+> = 0;
+
+
+//-----------------------------------------------------------------------------
+// Structs
+//-----------------------------------------------------------------------------
+struct VertexData {
+	float4 pos : POSITION;
+	float2 uv : TEXCOORD0;
+};
+
+//-----------------------------------------------------------------------------
+// Samplers
+//-----------------------------------------------------------------------------
+sampler_state texture_sampler {
+	Filter    = Linear;
+	AddressU  = Mirror;
+	AddressV  = Mirror;
+};
+
+//-----------------------------------------------------------------------------
+// Functions
+//-----------------------------------------------------------------------------
+float4 PSWave(VertexData vtx) : TARGET {
+	const float ar = 1.0 * (float)ViewSize.y / (float)ViewSize.x;
+    float2 tc = vtx.uv;
+    const float2 center = float2(0.5 / ar, 0.5);
+    float4 color;
+
+    tc.x /= ar;
+
+    const float theta = radians(animate == 3 ? (Time.x * 5 % 360.0) : angle);
+    const float s =  sin(theta);
+    const float _s = sin(-theta);
+    const float c =  cos(theta);
+    const float _c = cos(-theta);
+
+    tc = float2(dot(tc - center, float2(c, -s)), dot(tc - center, float2(s, c)));
+        if(wave_type == 0)
+        {
+            switch(animate)
+            {
+                default:
+                    tc.x += amplitude * sin((tc.x * period * 10) + phase);
+                    break;
+                case 1:
+                    tc.x += (sin(Time.x) * amplitude) * sin((tc.x * period * 10) + phase);
+                    break;
+                case 2:
+                    tc.x += amplitude * sin((tc.x * period * 10) + Time.x);
+                    break;
+            }
+        }
+        else
+        {
+            switch(animate)
+            {
+                default:
+                    tc.x +=  amplitude * sin((tc.y * period * 10) + phase);
+                    break;
+                case 1:
+                    tc.x += (sin(Time.x) * amplitude) * sin((tc.y * period * 10) + phase);
+                    break;
+                case 2:
+                    tc.x += amplitude * sin((tc.y * period * 10) + Time.x);
+                    break;
+            }
+        }
+        tc = float2(dot(tc, float2(_c, -_s)), dot(tc, float2(_s, _c))) + center;
+
+        tc.x *= ar;
+
+        color = InputA.Sample(texture_sampler, tc);
+
+
+    return color;
+}
+
+
+technique Wave
+{
+	pass
+	{
+		vertex_shader = DefaultVertexShader(vtx);
+		pixel_shader = PSWave(vtx);
+	}
+}

--- a/data/examples/shaders/filter/zigzag.effect
+++ b/data/examples/shaders/filter/zigzag.effect
@@ -1,0 +1,223 @@
+// Copyright 2021 Radegast Stravinsky <radegast.ffxiv@gmail.com>
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+//	this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//	this list of conditions and the following disclaimer in the documentation
+//	and/or other materials provided with the distribution.
+// 3. Neither the name of the copyright holder nor the names of its contributors
+//	may be used to endorse or promote products derived from this software
+//	without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#include "../base.effect"
+//-----------------------------------------------------------------------------
+// Uniforms
+//-----------------------------------------------------------------------------
+
+// Provided by StreamFX
+uniform float4 Time<
+	bool automatic = true;
+>;
+uniform float4 ViewSize<
+	bool automatic = true;
+>;
+uniform texture2d InputA<
+	bool automatic = true;
+>;
+
+uniform float2 coordinates<
+	string name = "Coordinates (X, Y)";
+	string description = "Determines the center of the effect.";
+	string field_type = "slider";
+	float2 step = {0.01, 0.01};
+	float2 minimum = {0.0, 0.0};
+	float2 maximum = {1.0, 1.0};
+> = {0.5, 0.5};
+
+uniform float angle<
+	string name = "Angle";
+	string description = "The angle in degrees to twist the image.";
+	string field_type = "slider";
+	float minimum = -1800.0;
+	float maximum = 1800.0;
+> = 270.0;
+
+uniform int mode<
+	string name = "Zigzag Type";
+	string description = "The zigzag distortion type to use.";
+	string field_type = "enum";
+	// Enumeration
+	int enum = 2;
+	int enum_0 = 0;
+	string enum_0_name = "Around Center";
+	int enum_1 = 1;
+	string enum_1_name = "Out From Center";
+> = 0;
+
+uniform float amplitude<
+	string name = "Amplitude";
+	string description = "Adjusts the amplitude of the wave.";
+	string field_type = "slider";
+	float minimum = -5.0;
+	float maximum = 5.0;
+> = 0.25;
+
+uniform float period<
+	string name = "Period";
+	string description = "The frequency at which the wave oscillation occurs.";
+	string field_type = "slider";
+	float minimum = 0.0;
+	float maximum = 10.0;
+> = 0.5;
+
+uniform float phase<
+    string name = "Phase";
+    string description = "Adjusts the phase of the wave.";
+	string field_type = "slider";
+	float minimum = -1.0;
+	float maximum = 1.0;
+> = 0.0;
+
+uniform float radius<
+	string name = "Radius";
+	string description = "The radius of the effect.";
+	string field_type = "slider";
+	float step = 0.01;
+	float minimum = 0.0;
+	float maximum = 1.0;
+> = 0.5;
+
+uniform float tension<
+	string name = "Tension";
+	string description = "Controls how rapidly the distortion reaches the maximum value.";
+	string field_type = "slider";
+	float step = 0.01;
+	float minimum = 0.0;
+	float maximum = 10.0;
+> = 1.0;
+
+uniform float aspect_ratio<
+	string name = "Aspect Ratio";
+	string description = "Adjusts the aspect ratio for the associated distortion.";
+	string field_type = "slider";
+	float step = 0.01;
+	float minimum = -1;
+	float maximum = 1;
+> = 0.0;
+
+uniform int animate<
+	string name = "Animate By";
+	string description = "Animates the wave distortion by one of the parameters.";
+	string field_type = "enum";
+	// Enumeration
+	int enum = 3;
+	int enum_0 = 0;
+	string enum_0_name = "None";
+	int enum_1 = 1;
+	string enum_1_name = "Amplitude";
+	int enum_2 = 2;
+	string enum_2_name = "Phase";
+> = 0;
+
+uniform bool inverse_angle<
+	string name = "Use Inverse Angle";
+	string description = "Inverts the angle, making the edges more distorted than the center.";
+> = false;
+
+//-----------------------------------------------------------------------------
+// Structs
+//-----------------------------------------------------------------------------
+struct VertexData {
+	float4 pos : POSITION;
+	float2 uv : TEXCOORD0;
+};
+
+//-----------------------------------------------------------------------------
+// Samplers
+//-----------------------------------------------------------------------------
+sampler_state texture_sampler {
+	Filter    = Linear;
+	AddressU  = Mirror;
+	AddressV  = Mirror;
+};
+
+//-----------------------------------------------------------------------------
+// Functions
+//-----------------------------------------------------------------------------
+
+float2x2 swirlTransform(float theta) {
+    const float c = cos(theta);
+    const float s = sin(theta);
+
+    const float m1 = c;
+    const float m2 = -s;
+    const float m3 = s;
+    const float m4 = c;
+
+    return float2x2(
+        m1, m2,
+        m3, m4
+    );
+}
+
+float2x2 zigzagTransform(float dist) {
+    const float c = cos(dist);
+    return float2x2(
+        c, 0,
+        0, c
+    );
+}
+
+float4 PSZigZag(VertexData vtx) : TARGET {
+	const float ar_raw = 1.0 * ViewSize.y / ViewSize.x;
+    float ar = lerp(ar_raw, 1, aspect_ratio);
+    float2 center = coordinates/2.0;
+    float2 tc = vtx.uv - center;
+
+    center.x /= ar;
+    tc.x /= ar;
+
+    const float dist = distance(tc, center);
+    const float tension_radius = lerp(radius-dist, radius, tension);
+    const float percent = max(radius-dist, 0) / tension_radius;
+    const float percentSquared = percent * percent;
+    const float theta = percentSquared * (animate == 1 ? amplitude * sin(Time.x) : amplitude) * sin(percentSquared / period * radians(angle) + (phase + (animate == 2 ? Time.x : 0)));
+
+    if(!mode)
+    {
+        tc = mul(swirlTransform(theta), tc-center);
+    }
+    else
+    {
+        tc = mul(zigzagTransform(theta), tc-center);
+    }
+
+
+    tc += (2.0 * center);
+    tc.x *= ar;
+
+    return InputA.Sample(texture_sampler, tc);
+}
+
+technique ZigZag {
+	pass
+	{
+		vertex_shader = DefaultVertexShader(vtx);
+		pixel_shader = PSZigZag(vtx);
+	}
+}


### PR DESCRIPTION
### Explain the Pull Request
This PR does the following:
- New shader: Zigzag
  - Twists the source back and forth around a central point.
- New shader: Wave
  - Distorts the source by creating two wave types:
    - X/Y: Distorts the image via  a shearing motion.
    - X/X: Distorts the image by stretching and contracting in a periodic manner.
- New shader: Bulge/Pinch
  - Distorts the source by creating an illusion that the source is being inflated outwards or pinched inwards.

### Why is this necessary?
More additional shaders for users.

### Checklist
- [X] I will become the maintainer for this part of code.
- [ ] I have tested this code on all supported Platforms.
  - This code has only been tested on the following Platforms due to availability:
    - [X] Windows
    - [ ] Linux
    - [ ] Mac

### Related Issues
<!-- Is this PR related to another PR or Issue? List them here. -->
<!-- - #0000 Name of Issue -->
<!-- - #0001 Name of Issue -->
