### PR TITLE
Denoising: Restrict size to reasonable numbers

### DIFF
--- a/source/filters/filter-denoising.cpp
+++ b/source/filters/filter-denoising.cpp
@@ -253,7 +253,7 @@ void denoising_instance::video_render(gs_effect_t* effect)
 
 		// Capture the input.
 		if (obs_source_process_filter_begin(_self, GS_RGBA, OBS_ALLOW_DIRECT_RENDERING)) {
-			auto op = _input->render(width, height);
+			auto op = _input->render(_size.first, _size.second);
 
 			// Clear the buffer
 			gs_clear(GS_CLEAR_COLOR | GS_CLEAR_DEPTH, &blank, 0, 0);
@@ -269,7 +269,7 @@ void denoising_instance::video_render(gs_effect_t* effect)
 			// Render
 			bool srgb = gs_framebuffer_srgb_enabled();
 			gs_enable_framebuffer_srgb(gs_get_linear_srgb());
-			obs_source_process_filter_end(_self, obs_get_base_effect(OBS_EFFECT_DEFAULT), width, height);
+			obs_source_process_filter_end(_self, obs_get_base_effect(OBS_EFFECT_DEFAULT), _size.first, _size.second);
 			gs_enable_framebuffer_srgb(srgb);
 
 			// Reset GPU state

--- a/source/filters/filter-denoising.cpp
+++ b/source/filters/filter-denoising.cpp
@@ -180,10 +180,15 @@ uint32_t streamfx::filter::denoising::denoising_instance::get_height()
 
 void denoising_instance::video_tick(float_t time)
 {
+	auto parent = obs_filter_get_parent(_self);
 	auto target = obs_filter_get_target(_self);
 	auto width  = obs_source_get_base_width(target);
 	auto height = obs_source_get_base_height(target);
-	_size       = {width, height};
+
+	// Verify that the detected size makes sense.
+	if ((width > 0) && (height > 0)) {
+		_size = {width, height};
+	}
 
 	// Allow the provider to restrict the size.
 	if (target && _provider_ready) {


### PR DESCRIPTION
### Explain the Pull Request
Prevents invalid sizes from being used by the filter, which sometimes happens with Async Sources that aren't quite ready yet.
<!-- Describe the PR in as much detail as possible, leave nothing out. -->
<!-- If you think images or example videos help describe the PR, include them. -->

### Why is this necessary?
Some Async Sources do not have a size until later, resulting in problems.
<!-- What makes this PR necessary for StreamFX and it's users? -->

### Checklist
- [x] I will become the maintainer for this part of code.
- [x] I have tested this code on all supported Platforms.

### Related Issues
<!-- Is this PR related to another PR or Issue? List them here. -->
- #642 Denoising filter causes Async Sources to zoom in.
<!-- - #0001 Name of Issue -->
