### PR TITLE
Update Upscaling and Denoising Source Identifiers

### DIFF
--- a/source/filters/filter-denoising.cpp
+++ b/source/filters/filter-denoising.cpp
@@ -558,12 +558,15 @@ denoising_factory::denoising_factory()
 	}
 
 	// 3. In any other case, register the filter!
-	_info.id           = S_PREFIX "filter-video-denoising";
+	_info.id           = S_PREFIX "filter-denoising";
 	_info.type         = OBS_SOURCE_TYPE_FILTER;
 	_info.output_flags = OBS_SOURCE_VIDEO;
 
 	set_resolution_enabled(true);
 	finish_setup();
+
+	// Proxies
+	register_proxy("streamfx-filter-video-denoising");
 }
 
 const char* denoising_factory::get_name()

--- a/source/filters/filter-upscaling.cpp
+++ b/source/filters/filter-upscaling.cpp
@@ -507,12 +507,15 @@ upscaling_factory::upscaling_factory()
 	}
 
 	// 3. In any other case, register the filter!
-	_info.id           = S_PREFIX "filter-video-superresolution";
+	_info.id           = S_PREFIX "filter-upscaling";
 	_info.type         = OBS_SOURCE_TYPE_FILTER;
 	_info.output_flags = OBS_SOURCE_VIDEO /*| OBS_SOURCE_SRGB*/;
 
 	set_resolution_enabled(true);
 	finish_setup();
+
+	// Proxies
+	register_proxy("streamfx-filter-video-superresolution");
 }
 
 const char* upscaling_factory::get_name()


### PR DESCRIPTION
### Explain the Pull Request
Updates the primary identifiers of the Upscaling and Denoising filter to be the same as their new name.
<!-- Describe the PR in as much detail as possible, leave nothing out. -->
<!-- If you think images or example videos help describe the PR, include them. -->

### Why is this necessary?
0.11.0a4 incorrectly ships the filters with their old identifiers as the primary identifiers.
<!-- What makes this PR necessary for StreamFX and it's users? -->

### Checklist
- [x] I will become the maintainer for this part of code.
- [x] I have tested this code on all supported Platforms.

### Related Issues
<!-- Is this PR related to another PR or Issue? List them here. -->
<!-- - #0000 Name of Issue -->
<!-- - #0001 Name of Issue -->
