### PR TITLE
Restore Alpha after Upscaling and Denoising

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1174,6 +1174,7 @@ list(APPEND PROJECT_DATA
 	"data/effects/color_conversion_rgb_yuv.effect"
 	"data/effects/mipgen.effect"
 	"data/effects/pack-unpack.effect"
+	"data/effects/standard.effect"
 	"data/effects/shared.effect"
 	"data/locale/en-US.ini"
 )

--- a/data/effects/shared.effect
+++ b/data/effects/shared.effect
@@ -16,6 +16,9 @@ uniform float4x4 ViewProj;
 //------------------------------------------------------------------------------
 // Samplers
 //------------------------------------------------------------------------------
+sampler_state BlankSampler {
+};
+
 sampler_state PointRepeatSampler {
 	Filter = Point;
 	AddressU = Repeat;

--- a/data/effects/standard.effect
+++ b/data/effects/standard.effect
@@ -1,0 +1,27 @@
+#include "shared.effect"
+
+uniform texture2D Channel0;
+uniform texture2D Channel1;
+
+//------------------------------------------------------------------------------
+// Technique: Restore Alpha
+//------------------------------------------------------------------------------
+// Parameters:
+// - Channel0: RGBX Texture
+// - Channel1: XXXA Texture
+
+float4 PSRestoreAlpha(VertexData vtx) : TARGET {
+	float4 rgbx = Channel0.Sample(BlankSampler, vtx.uv);
+	float4 xxxa = Channel1.Sample(BlankSampler, vtx.uv);
+	rgbx.a = xxxa.a;
+	return rgbx;
+};
+
+technique RestoreAlpha
+{
+	pass
+	{
+		vertex_shader = DefaultVertexShader(vtx);
+		pixel_shader = PSRestoreAlpha(vtx);
+	};
+};

--- a/source/filters/filter-denoising.cpp
+++ b/source/filters/filter-denoising.cpp
@@ -97,6 +97,20 @@ denoising_instance::denoising_instance(obs_data_t* data, obs_source_t* self)
 		_input = std::make_shared<::streamfx::obs::gs::rendertarget>(GS_RGBA_UNORM, GS_ZS_NONE);
 		_input->render(1, 1); // Preallocate the RT on the driver and GPU.
 		_output = _input->get_texture();
+
+		// Load the required effect.
+		_standard_effect =
+			std::make_shared<::streamfx::obs::gs::effect>(::streamfx::data_file_path("effects/standard.effect"));
+
+		// Create Samplers
+		_channel0_sampler = std::make_shared<::streamfx::obs::gs::sampler>();
+		_channel0_sampler->set_filter(gs_sample_filter::GS_FILTER_LINEAR);
+		_channel0_sampler->set_address_mode_u(GS_ADDRESS_CLAMP);
+		_channel0_sampler->set_address_mode_v(GS_ADDRESS_CLAMP);
+		_channel1_sampler = std::make_shared<::streamfx::obs::gs::sampler>();
+		_channel1_sampler->set_filter(gs_sample_filter::GS_FILTER_LINEAR);
+		_channel1_sampler->set_address_mode_u(GS_ADDRESS_CLAMP);
+		_channel1_sampler->set_address_mode_v(GS_ADDRESS_CLAMP);
 	}
 
 	if (data) {
@@ -375,8 +389,13 @@ void denoising_instance::video_render(gs_effect_t* effect)
 #ifdef ENABLE_PROFILING
 		::streamfx::obs::gs::debug_marker profiler1{::streamfx::obs::gs::debug_color_render, "Render"};
 #endif
-		gs_effect_set_texture(gs_effect_get_param_by_name(effect, "image"), _output->get_object());
-		while (gs_effect_loop(effect, "Draw")) {
+		if (_standard_effect->has_parameter("Channel0", ::streamfx::obs::gs::effect_parameter::type::Texture)) {
+			_standard_effect->get_parameter("Channel0").set_texture(_output);
+		}
+		if (_standard_effect->has_parameter("Channel1", ::streamfx::obs::gs::effect_parameter::type::Texture)) {
+			_standard_effect->get_parameter("Channel1").set_texture(_input->get_texture());
+		}
+		while (gs_effect_loop(_standard_effect->get_object(), "RestoreAlpha")) {
 			gs_draw_sprite(nullptr, 0, _size.first, _size.second);
 		}
 	}
@@ -560,7 +579,7 @@ denoising_factory::denoising_factory()
 	// 3. In any other case, register the filter!
 	_info.id           = S_PREFIX "filter-video-denoising";
 	_info.type         = OBS_SOURCE_TYPE_FILTER;
-	_info.output_flags = OBS_SOURCE_VIDEO;
+	_info.output_flags = OBS_SOURCE_VIDEO | OBS_SOURCE_CUSTOM_DRAW;
 
 	set_resolution_enabled(true);
 	finish_setup();

--- a/source/filters/filter-denoising.hpp
+++ b/source/filters/filter-denoising.hpp
@@ -22,6 +22,7 @@
 #include <atomic>
 #include <memory>
 #include <mutex>
+#include "obs/gs/gs-effect.hpp"
 #include "obs/gs/gs-rendertarget.hpp"
 #include "obs/gs/gs-texture.hpp"
 #include "obs/obs-source-factory.hpp"
@@ -51,6 +52,10 @@ namespace streamfx::filter::denoising {
 		std::atomic<bool>                       _provider_ready;
 		std::mutex                              _provider_lock;
 		std::shared_ptr<util::threadpool::task> _provider_task;
+
+		std::shared_ptr<::streamfx::obs::gs::effect>  _standard_effect;
+		std::shared_ptr<::streamfx::obs::gs::sampler> _channel0_sampler;
+		std::shared_ptr<::streamfx::obs::gs::sampler> _channel1_sampler;
 
 		std::shared_ptr<::streamfx::obs::gs::rendertarget> _input;
 		std::shared_ptr<::streamfx::obs::gs::texture>      _output;

--- a/source/filters/filter-upscaling.cpp
+++ b/source/filters/filter-upscaling.cpp
@@ -102,6 +102,20 @@ upscaling_instance::upscaling_instance(obs_data_t* data, obs_source_t* self)
 		_input = std::make_shared<::streamfx::obs::gs::rendertarget>(GS_RGBA_UNORM, GS_ZS_NONE);
 		_input->render(1, 1); // Preallocate the RT on the driver and GPU.
 		_output = _input->get_texture();
+
+		// Load the required effect.
+		_standard_effect =
+			std::make_shared<::streamfx::obs::gs::effect>(::streamfx::data_file_path("effects/standard.effect"));
+
+		// Create Samplers
+		_channel0_sampler = std::make_shared<::streamfx::obs::gs::sampler>();
+		_channel0_sampler->set_filter(gs_sample_filter::GS_FILTER_LINEAR);
+		_channel0_sampler->set_address_mode_u(GS_ADDRESS_CLAMP);
+		_channel0_sampler->set_address_mode_v(GS_ADDRESS_CLAMP);
+		_channel1_sampler = std::make_shared<::streamfx::obs::gs::sampler>();
+		_channel1_sampler->set_filter(gs_sample_filter::GS_FILTER_LINEAR);
+		_channel1_sampler->set_address_mode_u(GS_ADDRESS_CLAMP);
+		_channel1_sampler->set_address_mode_v(GS_ADDRESS_CLAMP);
 	}
 
 	if (data) {
@@ -231,8 +245,7 @@ void upscaling_instance::video_render(gs_effect_t* effect)
 	}
 
 #ifdef ENABLE_PROFILING
-	::streamfx::obs::gs::debug_marker profiler0{::streamfx::obs::gs::debug_color_source,
-												"StreamFX Video Super-Resolution"};
+	::streamfx::obs::gs::debug_marker profiler0{::streamfx::obs::gs::debug_color_source, "StreamFX Upscaling"};
 	::streamfx::obs::gs::debug_marker profiler0_0{::streamfx::obs::gs::debug_color_gray, "'%s' on '%s'",
 												  obs_source_get_name(_self), obs_source_get_name(parent)};
 #endif
@@ -310,8 +323,13 @@ void upscaling_instance::video_render(gs_effect_t* effect)
 #ifdef ENABLE_PROFILING
 		::streamfx::obs::gs::debug_marker profiler1{::streamfx::obs::gs::debug_color_render, "Render"};
 #endif
-		gs_effect_set_texture(gs_effect_get_param_by_name(effect, "image"), _output->get_object());
-		while (gs_effect_loop(effect, "Draw")) {
+		if (_standard_effect->has_parameter("Channel0", ::streamfx::obs::gs::effect_parameter::type::Texture)) {
+			_standard_effect->get_parameter("Channel0").set_texture(_output);
+		}
+		if (_standard_effect->has_parameter("Channel1", ::streamfx::obs::gs::effect_parameter::type::Texture)) {
+			_standard_effect->get_parameter("Channel1").set_texture(_input->get_texture());
+		}
+		while (gs_effect_loop(_standard_effect->get_object(), "RestoreAlpha")) {
 			gs_draw_sprite(nullptr, 0, _out_size.first, _out_size.second);
 		}
 	}
@@ -509,7 +527,7 @@ upscaling_factory::upscaling_factory()
 	// 3. In any other case, register the filter!
 	_info.id           = S_PREFIX "filter-video-superresolution";
 	_info.type         = OBS_SOURCE_TYPE_FILTER;
-	_info.output_flags = OBS_SOURCE_VIDEO /*| OBS_SOURCE_SRGB*/;
+	_info.output_flags = OBS_SOURCE_VIDEO | OBS_SOURCE_CUSTOM_DRAW /*| OBS_SOURCE_SRGB*/;
 
 	set_resolution_enabled(true);
 	finish_setup();

--- a/source/filters/filter-upscaling.hpp
+++ b/source/filters/filter-upscaling.hpp
@@ -22,6 +22,7 @@
 #include <atomic>
 #include <memory>
 #include <mutex>
+#include "obs/gs/gs-effect.hpp"
 #include "obs/gs/gs-rendertarget.hpp"
 #include "obs/gs/gs-texture.hpp"
 #include "obs/obs-source-factory.hpp"
@@ -52,6 +53,10 @@ namespace streamfx::filter::upscaling {
 		std::atomic<bool>                       _provider_ready;
 		std::mutex                              _provider_lock;
 		std::shared_ptr<util::threadpool::task> _provider_task;
+
+		std::shared_ptr<::streamfx::obs::gs::effect>  _standard_effect;
+		std::shared_ptr<::streamfx::obs::gs::sampler> _channel0_sampler;
+		std::shared_ptr<::streamfx::obs::gs::sampler> _channel1_sampler;
 
 		std::shared_ptr<::streamfx::obs::gs::rendertarget> _input;
 		std::shared_ptr<::streamfx::obs::gs::texture>      _output;


### PR DESCRIPTION
### Explain the Pull Request
None of the currently known Upscaling and Denoising algorithms handle Alpha, and some destroy the Alpha channel entirely. Instead of hoping to get a proper result from these, we should restore the Alpha channel manually and linearly interpolate it when necessary.
<!-- Describe the PR in as much detail as possible, leave nothing out. -->
<!-- If you think images or example videos help describe the PR, include them. -->

### Why is this necessary?
Alpha channel was destroyed when Denoising or Upscaling was applied.

### Checklist
- [x] I will become the maintainer for this part of code.
- [x] I have tested this code on all supported Platforms.

### Related Issues
<!-- Is this PR related to another PR or Issue? List them here. -->
- #646 
<!-- - #0001 Name of Issue -->
