### PR TITLE
project: Version 0.11.0a5

### DIFF
--- a/.github/ISSUE_TEMPLATE/issue.yml
+++ b/.github/ISSUE_TEMPLATE/issue.yml
@@ -34,6 +34,7 @@ body:
     label: "StreamFX Version"
     description: "On which StreamFX version did you first encounter this issue?"
     options:
+      - "0.11.0a5"
       - "0.11.0a4"
       - "0.11.0a3"
       - "0.11.0a2"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,7 @@ set(VERSION_MAJOR 0)
 set(VERSION_MINOR 11)
 set(VERSION_PATCH 0)
 set(VERSION_TWEAK 0)
-set(VERSION_SUFFIX "a4")
+set(VERSION_SUFFIX "a5")
 set(VERSION_COMMIT "00000000")
 
 # Check if we are in a git repository.


### PR DESCRIPTION

### Explain the Pull Request
- Updated the AOM library to libAOM v3.1.2-882-03b6f69.
- Fixed the Denoising filter not working correctly with unexpected sizes.
- Fixed the Denoising filter not rendering at the correct size.
- Fixed the Denoising and Upscaling filter destroying the Alpha channel.
- Fixed the Denoising filter running twice on the same image, resulting in a far worse image.
- Fixed Upscaling not automatically deciding on a proper scale factor for you when the selected one is not supported.
<!-- Describe the PR in as much detail as possible, leave nothing out. -->
<!-- If you think images or example videos help describe the PR, include them. -->

### Why is this necessary?
Releases v0.11.0a5
<!-- What makes this PR necessary for StreamFX and it's users? -->

### Checklist
- [ ] I will become the maintainer for this part of code.
- [ ] I have tested this code on all supported Platforms.

### Related Issues
<!-- Is this PR related to another PR or Issue? List them here. -->
<!-- - #0000 Name of Issue -->
<!-- - #0001 Name of Issue -->
