### PR TITLE
Fix some AOM AV1 Encoder issues

### DIFF
--- a/source/encoders/encoder-aom-av1.cpp
+++ b/source/encoders/encoder-aom-av1.cpp
@@ -426,8 +426,9 @@ aom_av1_instance::aom_av1_instance(obs_data_t* settings, obs_encoder_t* self, bo
 		}
 
 		{ // Tuning
-			_settings.tune_metric =
-				static_cast<aom_tune_metric>(obs_data_get_int(settings, ST_KEY_ADVANCED_TUNE_METRIC));
+			if (auto v = obs_data_get_int(settings, ST_KEY_ADVANCED_TUNE_METRIC); v != -1) {
+				_settings.tune_metric = static_cast<aom_tune_metric>(v);
+			}
 			_settings.tune_content =
 				static_cast<aom_tune_content>(obs_data_get_int(settings, ST_KEY_ADVANCED_TUNE_CONTENT));
 		}


### PR DESCRIPTION
### Explain the Pull Request
- Limits the Bitrate Overshoot range to the range specified in the updated library.
- Fixes automatic selection of the AV1 profile.
- The default setting for Tune Metric is now respected.
<!-- Describe the PR in as much detail as possible, leave nothing out. -->
<!-- If you think images or example videos help describe the PR, include them. -->

### Why is this necessary?
The AOM AV1 encoder is somewhat defective since updating the library.
<!-- What makes this PR necessary for StreamFX and it's users? -->

### Checklist
- [x] I will become the maintainer for this part of code.
- [x] I have tested this code on all supported Platforms.

### Related Issues
<!-- Is this PR related to another PR or Issue? List them here. -->
<!-- - #0000 Name of Issue -->
<!-- - #0001 Name of Issue -->
