### PR TITLE
filter/dynamic-mask: Prevent recursive filter graphs

### DIFF
--- a/source/filters/filter-dynamic-mask.hpp
+++ b/source/filters/filter-dynamic-mask.hpp
@@ -85,6 +85,9 @@ namespace streamfx::filter::dynamic_mask {
 		void hide() override;
 		void activate() override;
 		void deactivate() override;
+
+		bool acquire(std::string_view name);
+		void release();
 	};
 
 	class dynamic_mask_factory : public obs::source_factory<filter::dynamic_mask::dynamic_mask_factory,


### PR DESCRIPTION
### Explain the Pull Request
It was possible to create a recursive dependency tree with Dynamic Mask, which OBS Studio does not check against since it is a filter. Because of this, if a Dynamic Mask was created and not changed from its default settings, it and its parent source would survive scene collection changes and similar. 
<!-- Describe the PR in as much detail as possible, leave nothing out. -->
<!-- If you think images or example videos help describe the PR, include them. -->

### Why is this necessary?
Dynamic Mask was able to add a reference to its own parent source, enabling it to survive past its intended lifetime.
<!-- What makes this PR necessary for StreamFX and it's users? -->

### Checklist
- [x] I will become the maintainer for this part of code.
- [x] I have tested this code on all supported Platforms.

### Related Issues
<!-- Is this PR related to another PR or Issue? List them here. -->
<!-- - #0000 Name of Issue -->
<!-- - #0001 Name of Issue -->
