### PR TITLE
cmake: NVIDIA Video Effects SDK requires CUDA

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -929,6 +929,8 @@ if(REQUIRE_NVIDIA_VFX_SDK AND D_PLATFORM_WINDOWS)
 				"${PROJECT_SOURCE_DIR}/third-party/nvidia-maxine-vfx-sdk/nvvfx/src/"
 		)
 	endif()
+
+	set(REQUIRE_NVIDIA_CUDA ON)
 endif()
 
 #- NVIDIA CUDA (Windows)


### PR DESCRIPTION
### Explain the Pull Request
Fixes a missing dependency when building without Face Detection being available.
<!-- Describe the PR in as much detail as possible, leave nothing out. -->
<!-- If you think images or example videos help describe the PR, include them. -->

### Why is this necessary?
Upscaling, Denoising and Virtual Greenscreen depend on Video Effects SDK, which depends on CUDA. But this was not marked in the CMake files for those features.
<!-- What makes this PR necessary for StreamFX and it's users? -->

### Checklist
- [x] I will become the maintainer for this part of code.
- [x] I have tested this code on all supported Platforms.

### Related Issues
<!-- Is this PR related to another PR or Issue? List them here. -->
<!-- - #0000 Name of Issue -->
<!-- - #0001 Name of Issue -->
