### PR TITLE
util/library: Load wstring instead of string

### DIFF
--- a/source/util/util-library.cpp
+++ b/source/util/util-library.cpp
@@ -38,9 +38,9 @@ streamfx::util::library::library(std::filesystem::path file) : _library(nullptr)
 {
 #if defined(ST_WINDOWS)
 	SetLastError(ERROR_SUCCESS);
-	file     = ::streamfx::util::platform::utf8_to_native(file);
-	_library = reinterpret_cast<void*>(LoadLibraryExW(
-		file.wstring().c_str(), nullptr, LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR | LOAD_LIBRARY_SEARCH_DEFAULT_DIRS));
+	auto wfile = ::streamfx::util::platform::utf8_to_native(file.u8string());
+	_library   = reinterpret_cast<void*>(
+        LoadLibraryExW(wfile.c_str(), nullptr, LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR | LOAD_LIBRARY_SEARCH_DEFAULT_DIRS));
 	if (!_library) {
 		DWORD error = GetLastError();
 		if (error != ERROR_PROC_NOT_FOUND) {


### PR DESCRIPTION
### Explain the Pull Request
LoadLibraryW expects a WSTR, but we were giving it a STR. This resulted in unexplainable failures attempting to load libraries for some non-Western users.
<!-- Describe the PR in as much detail as possible, leave nothing out. -->
<!-- If you think images or example videos help describe the PR, include them. -->

### Why is this necessary?
Allows non-Western users to use the new features as intended.
<!-- What makes this PR necessary for StreamFX and it's users? -->

### Checklist
- [x] I will become the maintainer for this part of code.
- [x] I have tested this code on all supported Platforms.

### Related Issues
<!-- Is this PR related to another PR or Issue? List them here. -->
<!-- - #0000 Name of Issue -->
<!-- - #0001 Name of Issue -->
