### PR TITLE
Refactor Maxine SDK Wrappers

### DIFF
--- a/source/nvidia/cv/nvidia-cv.hpp
+++ b/source/nvidia/cv/nvidia-cv.hpp
@@ -288,7 +288,7 @@ namespace streamfx::nvidia::cv {
 		static std::shared_ptr<::streamfx::nvidia::cv::cv> get();
 	};
 
-	class exception : std::runtime_error {
+	class exception : public std::runtime_error {
 		result _code;
 
 		public:

--- a/source/nvidia/vfx/nvidia-vfx-denoising.hpp
+++ b/source/nvidia/vfx/nvidia-vfx-denoising.hpp
@@ -19,6 +19,7 @@
 // SOFTWARE.
 
 #pragma once
+#include "nvidia-vfx-effect.hpp"
 #include "nvidia-vfx.hpp"
 #include "nvidia/cuda/nvidia-cuda-gs-texture.hpp"
 #include "nvidia/cuda/nvidia-cuda-obs.hpp"
@@ -28,11 +29,8 @@
 #include "obs/gs/gs-texture.hpp"
 
 namespace streamfx::nvidia::vfx {
-	class denoising {
-		std::shared_ptr<::streamfx::nvidia::cuda::obs> _nvcuda;
-		std::shared_ptr<::streamfx::nvidia::cv::cv>    _nvcvi;
-		std::shared_ptr<::streamfx::nvidia::vfx::vfx>  _nvvfx;
-		std::shared_ptr<void>                          _fx;
+	class denoising : protected effect {
+		bool _dirty;
 
 		std::shared_ptr<::streamfx::nvidia::cv::texture> _input;
 		std::shared_ptr<::streamfx::nvidia::cv::image>   _convert_to_fp32;
@@ -41,13 +39,12 @@ namespace streamfx::nvidia::vfx {
 		std::shared_ptr<::streamfx::nvidia::cv::image>   _convert_to_u8;
 		std::shared_ptr<::streamfx::nvidia::cv::texture> _output;
 		std::shared_ptr<::streamfx::nvidia::cv::image>   _tmp;
-		void*                                            _states[1];
-		::streamfx::nvidia::cuda::device_ptr_t           _state;
-		uint32_t                                         _state_size;
+
+		void*                                  _states[1];
+		::streamfx::nvidia::cuda::device_ptr_t _state;
+		uint32_t                               _state_size;
 
 		float _strength;
-
-		bool _dirty;
 
 		public:
 		~denoising();

--- a/source/nvidia/vfx/nvidia-vfx-effect.hpp
+++ b/source/nvidia/vfx/nvidia-vfx-effect.hpp
@@ -39,15 +39,20 @@ namespace streamfx::nvidia::vfx {
 		std::shared_ptr<cuda::obs> _nvcuda;
 		std::shared_ptr<cv::cv>    _nvcvi;
 		std::shared_ptr<vfx>       _nvvfx;
-
-		std::shared_ptr<void> _fx;
-		bool                  _fx_dirty;
+		std::shared_ptr<void>      _fx;
+		std::string                _model_path;
 
 		public:
 		~effect();
 		effect(effect_t name);
 
-		inline cv::result set(parameter_t param, uint32_t value)
+		::streamfx::nvidia::vfx::handle_t get()
+		{
+			return _fx.get();
+		}
+
+		public /* Int32 */:
+		inline cv::result set(parameter_t param, uint32_t const value)
 		{
 			return _nvvfx->NvVFX_SetU32(_fx.get(), param, value);
 		};
@@ -56,7 +61,7 @@ namespace streamfx::nvidia::vfx {
 			return _nvvfx->NvVFX_GetU32(_fx.get(), param, &value);
 		};
 
-		inline cv::result set(parameter_t param, int32_t value)
+		inline cv::result set(parameter_t param, int32_t const value)
 		{
 			return _nvvfx->NvVFX_SetS32(_fx.get(), param, value);
 		};
@@ -65,7 +70,8 @@ namespace streamfx::nvidia::vfx {
 			return _nvvfx->NvVFX_GetS32(_fx.get(), param, &value);
 		};
 
-		inline cv::result set(parameter_t param, uint64_t value)
+		public /* Int64 */:
+		inline cv::result set(parameter_t param, uint64_t const value)
 		{
 			return _nvvfx->NvVFX_SetU64(_fx.get(), param, value);
 		};
@@ -74,7 +80,8 @@ namespace streamfx::nvidia::vfx {
 			return _nvvfx->NvVFX_GetU64(_fx.get(), param, &value);
 		};
 
-		inline cv::result set(parameter_t param, float value)
+		public /* Float32 */:
+		inline cv::result set(parameter_t param, float const value)
 		{
 			return _nvvfx->NvVFX_SetF32(_fx.get(), param, value);
 		};
@@ -83,7 +90,8 @@ namespace streamfx::nvidia::vfx {
 			return _nvvfx->NvVFX_GetF32(_fx.get(), param, &value);
 		};
 
-		inline cv::result set(parameter_t param, double value)
+		public /* Float64 */:
+		inline cv::result set(parameter_t param, double const value)
 		{
 			return _nvvfx->NvVFX_SetF64(_fx.get(), param, value);
 		};
@@ -92,7 +100,8 @@ namespace streamfx::nvidia::vfx {
 			return _nvvfx->NvVFX_GetF64(_fx.get(), param, &value);
 		};
 
-		inline cv::result set(parameter_t param, const char* value)
+		public /* String */:
+		inline cv::result set(parameter_t param, const char* const value)
 		{
 			return _nvvfx->NvVFX_SetString(_fx.get(), param, value);
 		};
@@ -101,19 +110,20 @@ namespace streamfx::nvidia::vfx {
 			return _nvvfx->NvVFX_GetString(_fx.get(), param, &value);
 		};
 
-		inline cv::result set(parameter_t param, std::string_view value)
+		inline cv::result set(parameter_t param, std::string_view const& value)
 		{
 			return _nvvfx->NvVFX_SetString(_fx.get(), param, value.data());
 		};
 		cv::result get(parameter_t param, std::string_view& value);
 
-		inline cv::result set(parameter_t param, std::string value)
+		inline cv::result set(parameter_t param, std::string const& value)
 		{
 			return _nvvfx->NvVFX_SetString(_fx.get(), param, value.c_str());
 		};
 		cv::result get(parameter_t param, std::string& value);
 
-		inline cv::result set(parameter_t param, cuda::stream_t value)
+		public /* CUDA Stream */:
+		inline cv::result set(parameter_t param, cuda::stream_t const& value)
 		{
 			return _nvvfx->NvVFX_SetCudaStream(_fx.get(), param, value);
 		};
@@ -122,22 +132,23 @@ namespace streamfx::nvidia::vfx {
 			return _nvvfx->NvVFX_GetCudaStream(_fx.get(), param, &value);
 		};
 
-		inline cv::result set(parameter_t param, std::shared_ptr<cuda::stream> value)
+		inline cv::result set(parameter_t param, std::shared_ptr<cuda::stream> const& value)
 		{
 			return _nvvfx->NvVFX_SetCudaStream(_fx.get(), param, value->get());
 		};
 		//cv::result get_stream(parameter_t param, std::shared_ptr<cuda::stream>& value);
 
-		inline cv::result set(parameter_t param, cv::image_t& value)
+		public /* CV Image */:
+		inline cv::result set(parameter_t param, cv::image_t* value)
 		{
-			return _nvvfx->NvVFX_SetImage(_fx.get(), param, &value);
+			return _nvvfx->NvVFX_SetImage(_fx.get(), param, value);
 		};
-		inline cv::result get(parameter_t param, cv::image_t& value)
+		inline cv::result get(parameter_t param, cv::image_t* value)
 		{
-			return _nvvfx->NvVFX_GetImage(_fx.get(), param, &value);
+			return _nvvfx->NvVFX_GetImage(_fx.get(), param, value);
 		};
 
-		inline cv::result set(parameter_t param, std::shared_ptr<cv::image> value)
+		inline cv::result set(parameter_t param, std::shared_ptr<cv::image> const& value)
 		{
 			return _nvvfx->NvVFX_SetImage(_fx.get(), param, value->get_image());
 		};
@@ -146,13 +157,15 @@ namespace streamfx::nvidia::vfx {
 			return _nvvfx->NvVFX_GetImage(_fx.get(), param, value->get_image());
 		};
 
-		inline cv::result set(parameter_t param, std::shared_ptr<cv::texture> value)
+		public /* CV Texture */:
+		inline cv::result set(parameter_t param, std::shared_ptr<cv::texture> const& value)
 		{
 			return _nvvfx->NvVFX_SetImage(_fx.get(), param, value->get_image());
 		};
 		//cv::result get(parameter_t param, std::shared_ptr<cv::texture>& value);
 
-		inline cv::result set_object(parameter_t param, void* value)
+		public /* Objects */:
+		inline cv::result set_object(parameter_t param, void* const value)
 		{
 			return _nvvfx->NvVFX_SetObject(_fx.get(), param, value);
 		};
@@ -161,6 +174,7 @@ namespace streamfx::nvidia::vfx {
 			return _nvvfx->NvVFX_GetObject(_fx.get(), param, &value);
 		};
 
+		public /* Control */:
 		inline cv::result load()
 		{
 			return _nvvfx->NvVFX_Load(_fx.get());

--- a/source/nvidia/vfx/nvidia-vfx-greenscreen.cpp
+++ b/source/nvidia/vfx/nvidia-vfx-greenscreen.cpp
@@ -64,16 +64,6 @@ streamfx::nvidia::vfx::greenscreen::greenscreen()
 	auto gctx = ::streamfx::obs::gs::context();
 	auto cctx = ::streamfx::nvidia::cuda::obs::get()->get_context()->enter();
 
-	// Assign CUDA Stream object.
-	if (auto v = set(PARAMETER_CUDA_STREAM, _nvcuda->get_stream()); v != cv::result::SUCCESS) {
-		throw ::streamfx::nvidia::cv::exception(PARAMETER_CUDA_STREAM, v);
-	}
-
-	// Assign Model Directory.
-	if (auto v = set(PARAMETER_MODEL_DIRECTORY, _nvvfx->model_path().generic_u8string()); v != cv::result::SUCCESS) {
-		throw ::streamfx::nvidia::cv::exception(PARAMETER_MODEL_DIRECTORY, v);
-	}
-
 	// Mode
 	set_mode(greenscreen_mode::QUALITY);
 

--- a/source/nvidia/vfx/nvidia-vfx-superresolution.hpp
+++ b/source/nvidia/vfx/nvidia-vfx-superresolution.hpp
@@ -19,6 +19,7 @@
 // SOFTWARE.
 
 #pragma once
+#include "nvidia-vfx-effect.hpp"
 #include "nvidia-vfx.hpp"
 #include "nvidia/cuda/nvidia-cuda-gs-texture.hpp"
 #include "nvidia/cuda/nvidia-cuda-obs.hpp"
@@ -28,12 +29,8 @@
 #include "obs/gs/gs-texture.hpp"
 
 namespace streamfx::nvidia::vfx {
-	class superresolution {
-		std::shared_ptr<::streamfx::nvidia::cuda::obs> _nvcuda;
-		std::shared_ptr<::streamfx::nvidia::cv::cv>    _nvcvi;
-		std::shared_ptr<::streamfx::nvidia::vfx::vfx>  _nvvfx;
-		std::shared_ptr<void>                          _fx;
-
+	class superresolution : protected effect {
+		bool                                             _dirty;
 		std::shared_ptr<::streamfx::nvidia::cv::texture> _input;
 		std::shared_ptr<::streamfx::nvidia::cv::image>   _convert_to_fp32;
 		std::shared_ptr<::streamfx::nvidia::cv::image>   _source;
@@ -44,8 +41,6 @@ namespace streamfx::nvidia::vfx {
 
 		float _strength;
 		float _scale;
-
-		bool _dirty;
 
 		std::pair<uint32_t, uint32_t> _cache_input_size;
 		std::pair<uint32_t, uint32_t> _cache_output_size;

--- a/source/nvidia/vfx/nvidia-vfx.cpp
+++ b/source/nvidia/vfx/nvidia-vfx.cpp
@@ -220,7 +220,7 @@ std::shared_ptr<::streamfx::nvidia::vfx::vfx> streamfx::nvidia::vfx::vfx::get()
 	return instance.lock();
 }
 
-std::filesystem::path streamfx::nvidia::vfx::vfx::model_path()
+std::filesystem::path const& streamfx::nvidia::vfx::vfx::model_path()
 {
 	return _model_path;
 }

--- a/source/nvidia/vfx/nvidia-vfx.hpp
+++ b/source/nvidia/vfx/nvidia-vfx.hpp
@@ -71,7 +71,7 @@ namespace streamfx::nvidia::vfx {
 		~vfx();
 		vfx();
 
-		std::filesystem::path model_path();
+		std::filesystem::path const& model_path();
 
 		public:
 		NVVFX_DEFINE_FUNCTION(NvVFX_GetVersion, uint32_t* version);


### PR DESCRIPTION
### Explain the Pull Request
- `cv::exception` now publicly inherits from `std::runtime_error` in order to make `what()` callable.
- VFX Wrapper returns a const-by-reference to improve performance slightly.
- VFX Effect Wrapper automatically handles Model Path, CUDA Stream and also uses const-by-reference and by-reference to improve performance slightly.
- VFX Greenscreen refactored onto Effect Wrapper.
- VFX Denoising refactored onto Effect Wrapper.
- VFX Super-Resolution refactored onto Effect Wrapper.
<!-- Describe the PR in as much detail as possible, leave nothing out. -->
<!-- If you think images or example videos help describe the PR, include them. -->

### Why is this necessary?
We have common base classes for most effects that handle some of the heavier lifting for us, without needing to duplicate code at all. Additionally this prevents some issues from affecting only some effects and not all of them.
<!-- What makes this PR necessary for StreamFX and it's users? -->

### Checklist
- [x] I will become the maintainer for this part of code.
- [x] I have tested this code on all supported Platforms.

### Related Issues
<!-- Is this PR related to another PR or Issue? List them here. -->
<!-- - #0000 Name of Issue -->
<!-- - #0001 Name of Issue -->
