### PR TITLE
Fix some wonky Shader integration behavior

### DIFF
--- a/source/gfx/shader/gfx-shader-param-texture.cpp
+++ b/source/gfx/shader/gfx-shader-param-texture.cpp
@@ -199,7 +199,6 @@ void streamfx::gfx::shader::texture_parameter::properties(obs_properties_t* prop
 			obs_property_set_modified_callback2(p, modified_type, this);
 			obs_property_list_add_int(p, D_TRANSLATE(ST_I18N_TYPE_FILE), static_cast<int64_t>(texture_type::File));
 			obs_property_list_add_int(p, D_TRANSLATE(ST_I18N_TYPE_SOURCE), static_cast<int64_t>(texture_type::Source));
-			modified_type(this, props, p, settings);
 		}
 
 		{
@@ -229,6 +228,8 @@ void streamfx::gfx::shader::texture_parameter::properties(obs_properties_t* prop
 				},
 				obs::source_tracker::filter_scenes);
 		}
+
+		modified_type(this, props, nullptr, settings);
 	}
 }
 

--- a/source/gfx/shader/gfx-shader-param-texture.hpp
+++ b/source/gfx/shader/gfx-shader-param-texture.hpp
@@ -39,9 +39,10 @@ namespace streamfx::gfx {
 			std::list<texture_enum_data> _values;
 
 			// Data
-			texture_type _type;
-			bool         _active;
-			bool         _visible;
+			texture_type          _type;
+			bool                  _active;
+			bool                  _visible;
+			std::filesystem::path _default;
 
 			// Data: File
 			std::filesystem::path                       _file_path;
@@ -60,7 +61,7 @@ namespace streamfx::gfx {
 							  std::string prefix);
 			virtual ~texture_parameter();
 
-			void defaults(obs_data_t* settings) override{};
+			void defaults(obs_data_t* settings) override;
 
 			static bool modified_type(void*, obs_properties_t*, obs_property_t*, obs_data_t*);
 

--- a/source/gfx/shader/gfx-shader-param-texture.hpp
+++ b/source/gfx/shader/gfx-shader-param-texture.hpp
@@ -1,6 +1,7 @@
 
 #pragma once
 #include <obs.h>
+#include <chrono>
 #include <mutex>
 #include "gfx-shader-param.hpp"
 #include "obs/gs/gs-rendertarget.hpp"
@@ -43,6 +44,10 @@ namespace streamfx::gfx {
 			bool                  _active;
 			bool                  _visible;
 			std::filesystem::path _default;
+
+			// Data: Dirty state
+			bool                                           _dirty;
+			std::chrono::high_resolution_clock::time_point _dirty_ts;
 
 			// Data: File
 			std::filesystem::path                       _file_path;

--- a/source/gfx/shader/gfx-shader.cpp
+++ b/source/gfx/shader/gfx-shader.cpp
@@ -508,9 +508,9 @@ void streamfx::gfx::shader::shader::render(gs_effect* effect)
 
 		auto op = _rt->render(width(), height());
 
+		vec4 zero = {0, 0, 0, 0};
+		gs_clear(GS_CLEAR_COLOR, &zero, 0, 0);
 		gs_ortho(0, 1, 0, 1, 0, 1);
-		/*vec4 zero = {0, 0, 0, 0};
-		gs_clear(GS_CLEAR_COLOR, &zero, 0, 0);*/
 
 		// Update Blend State
 		gs_blend_state_push();

--- a/source/gfx/shader/gfx-shader.cpp
+++ b/source/gfx/shader/gfx-shader.cpp
@@ -257,6 +257,7 @@ bool streamfx::gfx::shader::shader::on_refresh_properties(obs_properties_t* prop
 			obs_property_list_add_string(p_tech_list, tech.name().c_str(), tech.name().c_str());
 		}
 	}
+
 	{ // Clear parameter options.
 		auto grp = obs_property_group_content(obs_properties_get(props, ST_KEY_PARAMETERS));
 		for (auto p = obs_properties_first(grp); p != nullptr; p = obs_properties_first(grp)) {
@@ -267,14 +268,14 @@ bool streamfx::gfx::shader::shader::on_refresh_properties(obs_properties_t* prop
 		obs_data_t* data = obs_source_get_settings(_self);
 		for (auto kv : _shader_params) {
 			try {
-				kv.second->properties(grp, data);
 				kv.second->defaults(data);
 				kv.second->update(data);
+				kv.second->properties(grp, data);
 			} catch (...) {
 				// ToDo: Do something with these?
 			}
 		}
-		obs_source_update(_self, data);
+		//obs_source_update(_self, data);
 	}
 
 	return true;
@@ -366,6 +367,7 @@ void streamfx::gfx::shader::shader::update(obs_data_t* data)
 	}
 
 	for (auto kv : _shader_params) {
+		kv.second->defaults(data);
 		kv.second->update(data);
 	}
 }


### PR DESCRIPTION
### Explain the Pull Request
- Clears the render target before rendering to it again, fixing a continuously stacking render bug.
- Prevents default values from being stored by calling defaults before update.
- Added support for default textures.
- Fixed rare lock up from reacquire/reload behavior running all the time.
- Fixed the "Refresh" button not properly refreshing texture parameters.

### Related Issues
<!-- Is this PR related to another PR or Issue? List them here. -->
<!-- - #0000 Name of Issue -->
<!-- - #0001 Name of Issue -->

### Checklist
- [x] I will become the maintainer for this part of code.
- [x] I have tested this code on all supported Platforms.
