### PR TITLE
Improve Encoder behavior when used with OBS Studio

### DIFF
--- a/source/encoders/codecs/h264.cpp
+++ b/source/encoders/codecs/h264.cpp
@@ -20,3 +20,68 @@
 // SOFTWARE.
 
 #include "h264.hpp"
+
+uint8_t* is_nal_start(uint8_t* ptr, uint8_t* end_ptr, size_t& size)
+{
+	// Ensure that the remaining space actually can contain a prefix and NAL header.
+	if ((ptr + (3 + 1)) >= end_ptr)
+		return nullptr;
+
+	if (*ptr != 0x0)
+		return nullptr;
+	if (*(ptr + 1) != 0x0)
+		return nullptr;
+
+	// 3-Byte NAL prefix.
+	if (*(ptr + 2) == 0x1) {
+		size = 3;
+		return ptr + 3;
+	}
+
+	// 4-Byte NAL Prefix
+	if ((ptr + (4 + 1)) >= end_ptr)
+		return nullptr;
+	if (*(ptr + 2) != 0x0)
+		return nullptr;
+	if (*(ptr + 3) != 0x01)
+		return nullptr;
+
+	size = 4;
+	return ptr + 4;
+}
+
+uint8_t* streamfx::encoder::codec::h264::find_closest_nal(uint8_t* ptr, uint8_t* end_ptr, size_t& size)
+{
+	for (uint8_t* seek_ptr = ptr; seek_ptr < end_ptr; seek_ptr++) {
+		if (auto nal_ptr = is_nal_start(seek_ptr, end_ptr, size); nal_ptr != nullptr)
+			return nal_ptr;
+	}
+	return nullptr;
+}
+
+uint32_t streamfx::encoder::codec::h264::get_packet_reference_count(uint8_t* ptr, uint8_t* end_ptr)
+{
+	size_t   nal_ptr_prefix = 0;
+	uint8_t* nal_ptr        = find_closest_nal(ptr, end_ptr, nal_ptr_prefix);
+	while ((nal_ptr != nullptr) && (nal_ptr < end_ptr)) {
+		// Try and figure out the actual size of the NAL.
+		size_t   nal_end_ptr_prefix = 0;
+		uint8_t* nal_end_ptr        = find_closest_nal(nal_ptr, end_ptr, nal_end_ptr_prefix);
+		size_t   nal_size           = (nal_end_ptr ? nal_end_ptr : end_ptr) - nal_ptr - nal_end_ptr_prefix;
+
+		// Try and figure out the ideal priority.
+		switch (static_cast<nal_unit_type>((*nal_ptr) & 0x5)) {
+		case nal_unit_type::CODED_SLICE_NONIDR:
+			return (*nal_ptr >> 5) & 0x2;
+		case nal_unit_type::CODED_SLICE_IDR:
+			return (*nal_ptr >> 5) & 0x2;
+		default:
+			break;
+		}
+
+		// Update our NAL pointer.
+		nal_ptr = nal_end_ptr;
+	}
+
+	return std::numeric_limits<uint32_t>::max();
+}

--- a/source/encoders/codecs/h264.hpp
+++ b/source/encoders/codecs/h264.hpp
@@ -60,4 +60,40 @@ namespace streamfx::encoder::codec::h264 {
 		L6_2,
 		UNKNOWN = -1,
 	};
+
+	// See ITU-T H.264
+	enum class nal_unit_type : uint8_t {
+		UNSPECIFIED                          = 0,
+		CODED_SLICE_NONIDR                   = 1,
+		CODED_SLICE_DATA_PARTITION_A         = 2,
+		CODED_SLICE_DATA_PARTITION_B         = 3,
+		CODED_SLICE_DATA_PARTITION_C         = 4,
+		CODED_SLICE_IDR                      = 5,
+		SUPPLEMENTAL_ENHANCEMENT_INFORMATION = 6,
+		SEQUENCE_PARAMETER_SET               = 7,
+		PICTURE_PARAMETER_SET                = 8,
+		ACCESS_UNIT_DELIMITER                = 9,
+		END_OF_SEQUENCE                      = 10,
+		END_OF_STREAM                        = 11,
+		FILLER_DATA                          = 12,
+		SEQUENCE_PARAMETER_SET_EXTENSION     = 13,
+		PREFIX_NAL_UNIT                      = 14,
+		SUBSET_SEQUENCE_PARAMETER_SET        = 15,
+		DEPTH_PARAMETER_SET                  = 16,
+		CODED_SLICE_AUXILIARY_PICTURE        = 19,
+		CODED_SLICE_EXTENSION                = 20,
+		CODED_SLICE_EXTENSION_DEPTH_VIEW     = 21,
+	};
+
+	/** Search for the closest NAL unit.
+	 *
+	 * \param ptr Beginning of the search range.
+	 * \param endptr End of the search range (exclusive).
+	 * 
+	 * \return A valid pointer if a NAL was found, otherwise \ref nullptr.
+	 */
+	uint8_t* find_closest_nal(uint8_t* ptr, uint8_t* endptr, size_t& size);
+
+	uint32_t get_packet_reference_count(uint8_t* ptr, uint8_t* endptr);
+
 } // namespace streamfx::encoder::codec::h264

--- a/source/encoders/encoder-aom-av1.cpp
+++ b/source/encoders/encoder-aom-av1.cpp
@@ -1125,16 +1125,16 @@ bool streamfx::encoder::aom::av1::aom_av1_instance::encode_video(encoder_frame* 
 								   || (_cfg.g_usage == AOM_USAGE_ALL_INTRA);
 				if (packet->keyframe) {
 					//
-					packet->priority      = 0;
-					packet->drop_priority = packet->priority;
+					packet->priority      = 3; // OBS_NAL_PRIORITY_HIGHEST
+					packet->drop_priority = 3; // OBS_NAL_PRIORITY_HIGHEST
 				} else if ((pkt->data.frame.flags & AOM_FRAME_IS_DROPPABLE) != AOM_FRAME_IS_DROPPABLE) {
 					// Dropping this frame breaks the bitstream.
-					packet->priority      = -1;
-					packet->drop_priority = packet->priority;
+					packet->priority      = 2; // OBS_NAL_PRIORITY_HIGH
+					packet->drop_priority = 3; // OBS_NAL_PRIORITY_HIGHEST
 				} else {
 					// This frame can be dropped at will.
-					packet->priority      = -2;
-					packet->drop_priority = packet->priority;
+					packet->priority      = 0; // OBS_NAL_PRIORITY_DISPOSABLE
+					packet->drop_priority = 0; // OBS_NAL_PRIORITY_DISPOSABLE
 				}
 
 				// Data

--- a/source/encoders/encoder-ffmpeg.cpp
+++ b/source/encoders/encoder-ffmpeg.cpp
@@ -970,6 +970,12 @@ void ffmpeg_factory::get_defaults2(obs_data_t* settings)
 	}
 }
 
+void ffmpeg_factory::migrate(obs_data_t* data, uint64_t version)
+{
+	if (_handler)
+		_handler->migrate(data, version, _avcodec, nullptr);
+}
+
 static bool modified_keyframes(obs_properties_t* props, obs_property_t*, obs_data_t* settings) noexcept
 try {
 	bool is_seconds = obs_data_get_int(settings, ST_KEY_KEYFRAMES_INTERVALTYPE) == 0;

--- a/source/encoders/encoder-ffmpeg.hpp
+++ b/source/encoders/encoder-ffmpeg.hpp
@@ -143,6 +143,8 @@ namespace streamfx::encoder::ffmpeg {
 
 		void get_defaults2(obs_data_t* data) override;
 
+		void migrate(obs_data_t* data, uint64_t version) override;
+
 		obs_properties_t* get_properties2(instance_t* data) override;
 
 #ifdef ENABLE_FRONTEND

--- a/source/encoders/handlers/handler.cpp
+++ b/source/encoders/handlers/handler.cpp
@@ -43,3 +43,8 @@ bool handler::handler::has_pixel_format_support(ffmpeg_factory* instance)
 {
 	return (instance->get_avcodec()->pix_fmts != nullptr);
 }
+
+bool handler::handler::supports_reconfigure(ffmpeg_factory* instance, bool& threads, bool& gpu, bool& keyframes)
+{
+	return false;
+}

--- a/source/encoders/handlers/handler.hpp
+++ b/source/encoders/handlers/handler.hpp
@@ -61,6 +61,8 @@ namespace streamfx::encoder::ffmpeg {
 
 			virtual bool has_pixel_format_support(ffmpeg_factory* instance);
 
+			virtual bool supports_reconfigure(ffmpeg_factory* instance, bool& threads, bool& gpu, bool& keyframes);
+
 			public /*settings*/:
 			virtual void get_properties(obs_properties_t* props, const AVCodec* codec, AVCodecContext* context,
 										bool hw_encode){};

--- a/source/encoders/handlers/nvenc_h264_handler.cpp
+++ b/source/encoders/handlers/nvenc_h264_handler.cpp
@@ -107,19 +107,20 @@ void nvenc_h264_handler::update(obs_data_t* settings, const AVCodec* codec, AVCo
 {
 	nvenc::update(settings, codec, context);
 
-	{
-		auto found = profiles.find(static_cast<profile>(obs_data_get_int(settings, ST_KEY_PROFILE)));
-		if (found != profiles.end()) {
-			av_opt_set(context->priv_data, "profile", found->second.c_str(), 0);
+	if (!context->internal) {
+		{
+			auto found = profiles.find(static_cast<profile>(obs_data_get_int(settings, ST_KEY_PROFILE)));
+			if (found != profiles.end()) {
+				av_opt_set(context->priv_data, "profile", found->second.c_str(), 0);
+			}
 		}
-	}
-
-	{
-		auto found = levels.find(static_cast<level>(obs_data_get_int(settings, ST_KEY_LEVEL)));
-		if (found != levels.end()) {
-			av_opt_set(context->priv_data, "level", found->second.c_str(), 0);
-		} else {
-			av_opt_set(context->priv_data, "level", "auto", 0);
+		{
+			auto found = levels.find(static_cast<level>(obs_data_get_int(settings, ST_KEY_LEVEL)));
+			if (found != levels.end()) {
+				av_opt_set(context->priv_data, "level", found->second.c_str(), 0);
+			} else {
+				av_opt_set(context->priv_data, "level", "auto", 0);
+			}
 		}
 	}
 }
@@ -182,4 +183,12 @@ void streamfx::encoder::ffmpeg::handler::nvenc_h264_handler::migrate(obs_data_t*
 																	 const AVCodec* codec, AVCodecContext* context)
 {
 	nvenc::migrate(settings, version, codec, context);
+}
+
+bool nvenc_h264_handler::supports_reconfigure(ffmpeg_factory* instance, bool& threads, bool& gpu, bool& keyframes)
+{
+	threads   = false;
+	gpu       = false;
+	keyframes = false;
+	return true;
 }

--- a/source/encoders/handlers/nvenc_h264_handler.hpp
+++ b/source/encoders/handlers/nvenc_h264_handler.hpp
@@ -54,6 +54,8 @@ namespace streamfx::encoder::ffmpeg::handler {
 
 		virtual bool has_pixel_format_support(ffmpeg_factory* instance);
 
+		virtual bool supports_reconfigure(ffmpeg_factory* instance, bool& threads, bool& gpu, bool& keyframes);
+
 		public /*settings*/:
 		virtual void get_properties(obs_properties_t* props, const AVCodec* codec, AVCodecContext* context,
 									bool hw_encode);

--- a/source/encoders/handlers/nvenc_hevc_handler.cpp
+++ b/source/encoders/handlers/nvenc_hevc_handler.cpp
@@ -108,24 +108,26 @@ void nvenc_hevc_handler::update(obs_data_t* settings, const AVCodec* codec, AVCo
 {
 	nvenc::update(settings, codec, context);
 
-	{ // HEVC Options
-		auto found = profiles.find(static_cast<profile>(obs_data_get_int(settings, ST_KEY_PROFILE)));
-		if (found != profiles.end()) {
-			av_opt_set(context->priv_data, "profile", found->second.c_str(), 0);
+	if (!context->internal) {
+		{ // HEVC Options
+			auto found = profiles.find(static_cast<profile>(obs_data_get_int(settings, ST_KEY_PROFILE)));
+			if (found != profiles.end()) {
+				av_opt_set(context->priv_data, "profile", found->second.c_str(), 0);
+			}
 		}
-	}
-	{
-		auto found = tiers.find(static_cast<tier>(obs_data_get_int(settings, ST_KEY_TIER)));
-		if (found != tiers.end()) {
-			av_opt_set(context->priv_data, "tier", found->second.c_str(), 0);
+		{
+			auto found = tiers.find(static_cast<tier>(obs_data_get_int(settings, ST_KEY_TIER)));
+			if (found != tiers.end()) {
+				av_opt_set(context->priv_data, "tier", found->second.c_str(), 0);
+			}
 		}
-	}
-	{
-		auto found = levels.find(static_cast<level>(obs_data_get_int(settings, ST_KEY_LEVEL)));
-		if (found != levels.end()) {
-			av_opt_set(context->priv_data, "level", found->second.c_str(), 0);
-		} else {
-			av_opt_set(context->priv_data, "level", "auto", 0);
+		{
+			auto found = levels.find(static_cast<level>(obs_data_get_int(settings, ST_KEY_LEVEL)));
+			if (found != levels.end()) {
+				av_opt_set(context->priv_data, "level", found->second.c_str(), 0);
+			} else {
+				av_opt_set(context->priv_data, "level", "auto", 0);
+			}
 		}
 	}
 }
@@ -199,4 +201,12 @@ void streamfx::encoder::ffmpeg::handler::nvenc_hevc_handler::migrate(obs_data_t*
 																	 const AVCodec* codec, AVCodecContext* context)
 {
 	nvenc::migrate(settings, version, codec, context);
+}
+
+bool nvenc_hevc_handler::supports_reconfigure(ffmpeg_factory* instance, bool& threads, bool& gpu, bool& keyframes)
+{
+	threads   = false;
+	gpu       = false;
+	keyframes = false;
+	return true;
 }

--- a/source/encoders/handlers/nvenc_hevc_handler.hpp
+++ b/source/encoders/handlers/nvenc_hevc_handler.hpp
@@ -54,6 +54,8 @@ namespace streamfx::encoder::ffmpeg::handler {
 
 		virtual bool has_pixel_format_support(ffmpeg_factory* instance);
 
+		virtual bool supports_reconfigure(ffmpeg_factory* instance, bool& threads, bool& gpu, bool& keyframes);
+
 		public /*settings*/:
 		virtual void get_properties(obs_properties_t* props, const AVCodec* codec, AVCodecContext* context,
 									bool hw_encode);

--- a/source/encoders/handlers/nvenc_shared.cpp
+++ b/source/encoders/handlers/nvenc_shared.cpp
@@ -602,9 +602,10 @@ void nvenc::update(obs_data_t* settings, const AVCodec* codec, AVCodecContext* c
 		if (have_bitrate_range) {
 			if (int64_t max = obs_data_get_int(settings, ST_KEY_RATECONTROL_LIMITS_BITRATE_MAXIMUM); max > -1)
 				context->rc_max_rate = static_cast<int>(max * 1000);
+			context->rc_min_rate = context->bit_rate;
 		} else {
-			//context->rc_min_rate = 0;
-			context->rc_max_rate = 0;
+			context->rc_min_rate = context->bit_rate;
+			context->rc_max_rate = context->bit_rate;
 		}
 
 		// Buffer Size

--- a/source/encoders/handlers/nvenc_shared.cpp
+++ b/source/encoders/handlers/nvenc_shared.cpp
@@ -711,7 +711,7 @@ void nvenc::update(obs_data_t* settings, const AVCodec* codec, AVCodecContext* c
 			!streamfx::util::is_tristate_default(nrp))
 			av_opt_set_int(context->priv_data, "nonref_p", nrp, AV_OPT_SEARCH_CHILDREN);
 		if (int64_t v = obs_data_get_int(settings, ST_KEY_OTHER_REFERENCEFRAMES); v > -1)
-			av_opt_set_int(context->priv_data, "refs", v, AV_OPT_SEARCH_CHILDREN);
+			context->refs = v;
 
 		int64_t wp = obs_data_get_int(settings, ST_KEY_OTHER_WEIGHTEDPREDICTION);
 		if ((context->max_b_frames > 0) && streamfx::util::is_tristate_enabled(wp)) {
@@ -779,7 +779,7 @@ void nvenc::log_options(obs_data_t*, const AVCodec* codec, AVCodecContext* conte
 	tools::print_av_option_bool(context, "zerolatency", "      Zero Latency");
 	tools::print_av_option_bool(context, "weighted_pred", "      Weighted Prediction");
 	tools::print_av_option_bool(context, "nonref_p", "      Non-reference P-Frames");
-	tools::print_av_option_int(context, "refs", "      REference Frames", "Frames");
+	tools::print_av_option_int(context, "refs", "      Reference Frames", "Frames");
 	tools::print_av_option_bool(context, "strict_gop", "      Strict GOP");
 	tools::print_av_option_bool(context, "aud", "      Access Unit Delimiters");
 	tools::print_av_option_bool(context, "bluray-compat", "      Bluray Compatibility");

--- a/source/encoders/handlers/nvenc_shared.cpp
+++ b/source/encoders/handlers/nvenc_shared.cpp
@@ -759,10 +759,10 @@ void streamfx::encoder::ffmpeg::handler::nvenc::migrate(obs_data_t* settings, ui
 	// Only test for A.B.C in A.B.C.D
 	version = version & STREAMFX_MASK_UPDATE;
 
-#define COPY_UNSET(TYPE, NAME, OLDNAME)                                              \
-	if (obs_data_has_user_value(settings, OLDNAME)) {                                \
-		obs_data_set_##TYPE(settings, NAME, obs_data_get_##TYPE(settings, OLDNAME)); \
-		obs_data_unset_user_value(settings, OLDNAME);                                \
+#define COPY_UNSET(TYPE, FROM, TO)                                              \
+	if (obs_data_has_user_value(settings, FROM)) {                              \
+		obs_data_set_##TYPE(settings, TO, obs_data_get_##TYPE(settings, FROM)); \
+		obs_data_unset_user_value(settings, FROM);                              \
 	}
 
 	if (version <= STREAMFX_MAKE_VERSION(0, 8, 0, 0)) {
@@ -774,7 +774,7 @@ void streamfx::encoder::ffmpeg::handler::nvenc::migrate(obs_data_t* settings, ui
 		COPY_UNSET(double, "RateControl.Quality.Target", ST_KEY_RATECONTROL_LIMITS_QUALITY);
 	}
 
-	if (version <= STREAMFX_MAKE_VERSION(0, 11, 0, 0)) {
+	if (version < STREAMFX_MAKE_VERSION(0, 11, 0, 0)) {
 		obs_data_unset_user_value(settings, "Other.AccessUnitDelimiter");
 		obs_data_unset_user_value(settings, "Other.DecodedPictureBufferSize");
 	}


### PR DESCRIPTION
### Explain the Pull Request
- NVENC (via FFmpeg) can now properly be used for Replay Buffer and sets the requested information during `obs_video_encoder_create`.
- NVENC (via FFmpeg) now also respects streaming service limits, which OBS sets in a 2nd call to `obs_encoder_update`.
- NVENC (via FFmpeg) now supports dynamic reconfiguration for bitrate.
- AOM AV1 (direct) no longer sets packet priority and drop priority to negative values when OBS expects positive numbers.
- FFmpeg Encoders now properly set packet priority and drop priority according to the reported frame type.
- FFmpeg Encoders now properly migrate settings in OBS Studio via a work-around involving modified_properties2.
- NVENC (via FFmpeg) no longer constantly attempts to transfer settings from older versions.

### Related Issues
<!-- Is this PR related to another PR or Issue? List them here. -->
<!-- - #0000 Name of Issue -->
<!-- - #0001 Name of Issue -->

### Checklist
- [x] I will become the maintainer for this part of code.
- [x] I have tested this code on all supported Platforms.
