### PR TITLE
Further improve FFmpeg support

### DIFF
--- a/.github/ISSUE_TEMPLATE/issue.yml
+++ b/.github/ISSUE_TEMPLATE/issue.yml
@@ -21,12 +21,13 @@ body:
     label: "OBS Studio Version?"
     description: "Which OBS Studio version are you using to run StreamFX? Versions include all patches (the third element in 'A.B.C'), and release candidates for that version. Select 'Other' if you are using a custom build."
     options:
+      - "27.2"
       - "27.1"
       - "27.0"
       - "26.1"
       - "26.0"
       - "25.0"
-      - "(Other)"
+      - "(Other, specify below)"
   validations:
     required: true
 - type: dropdown
@@ -34,6 +35,9 @@ body:
     label: "StreamFX Version"
     description: "On which StreamFX version did you first encounter this issue?"
     options:
+      - "0.11.1b1"
+      - "0.11.1a1"
+      - "0.11.0"
       - "0.11.0c1"
       - "0.11.0b3"
       - "0.11.0b2"
@@ -96,18 +100,19 @@ body:
       - "0.2.0"
       - "0.1.1"
       - "0.1.0"
+      - "(Other, specify below)"
   validations:
     required: true
 - type: input
   attributes:
     label: "OBS Studio Log"
-    description: "Upload a normal log file that showcases the issue happening. If you encountered a crash, also fill out the next field."
+    description: "Paste the link to the log file OBS Studio uploaded."
   validations:
     required: true
 - type: textarea
   attributes:
     label: "OBS Studio Crash Log"
-    description: "If OBS Studio crashed (not froze) paste the crash log here, or upload it somewhere and paste the link here."
+    description: "If OBS Studio crashed (not froze) paste the crash log here, or upload it somewhere and paste the link here. Do not paste the normal log file here."
 - type: textarea
   attributes:
     label: "Current Behavior"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,7 @@ set(VERSION_MAJOR 0)
 set(VERSION_MINOR 11)
 set(VERSION_PATCH 1)
 set(VERSION_TWEAK 0)
-set(VERSION_SUFFIX "a1")
+set(VERSION_SUFFIX "b1")
 set(VERSION_COMMIT "00000000")
 
 # Check if we are in a git repository.

--- a/source/encoders/handlers/nvenc_hevc_handler.cpp
+++ b/source/encoders/handlers/nvenc_hevc_handler.cpp
@@ -53,9 +53,9 @@ void nvenc_hevc_handler::get_defaults(obs_data_t* settings, const AVCodec* codec
 {
 	nvenc::get_defaults(settings, codec, context);
 
-	obs_data_set_default_int(settings, ST_KEY_PROFILE, static_cast<int64_t>(profile::MAIN));
-	obs_data_set_default_int(settings, ST_KEY_TIER, static_cast<int64_t>(profile::MAIN));
-	obs_data_set_default_int(settings, ST_KEY_LEVEL, static_cast<int64_t>(level::UNKNOWN));
+	obs_data_set_default_string(settings, ST_KEY_PROFILE, "");
+	obs_data_set_default_string(settings, ST_KEY_TIER, "");
+	obs_data_set_default_string(settings, ST_KEY_LEVEL, "auto");
 }
 
 bool nvenc_hevc_handler::has_keyframe_support(ffmpeg_factory*)
@@ -92,16 +92,14 @@ void nvenc_hevc_handler::update(obs_data_t* settings, const AVCodec* codec, AVCo
 	nvenc::update(settings, codec, context);
 
 	if (!context->internal) {
-		if (auto v = obs_data_get_int(settings, ST_KEY_PROFILE); v > -1) {
-			av_opt_set_int(context->priv_data, "profile", v, AV_OPT_SEARCH_CHILDREN);
+		if (auto v = obs_data_get_string(settings, ST_KEY_PROFILE); v && (strlen(v) > 0)) {
+			av_opt_set(context->priv_data, "profile", v, AV_OPT_SEARCH_CHILDREN);
 		}
-		if (auto v = obs_data_get_int(settings, ST_KEY_TIER); v > -1) {
-			av_opt_set_int(context->priv_data, "tier", v, AV_OPT_SEARCH_CHILDREN);
+		if (auto v = obs_data_get_string(settings, ST_KEY_TIER); v && (strlen(v) > 0)) {
+			av_opt_set(context->priv_data, "tier", v, AV_OPT_SEARCH_CHILDREN);
 		}
-		if (auto v = obs_data_get_int(settings, ST_KEY_LEVEL); v > -1) {
-			av_opt_set_int(context->priv_data, "level", v, AV_OPT_SEARCH_CHILDREN);
-		} else {
-			av_opt_set(context->priv_data, "level", "auto", AV_OPT_SEARCH_CHILDREN);
+		if (auto v = obs_data_get_string(settings, ST_KEY_LEVEL); v && (strlen(v) > 0)) {
+			av_opt_set(context->priv_data, "level", v, AV_OPT_SEARCH_CHILDREN);
 		}
 	}
 }
@@ -143,26 +141,36 @@ void nvenc_hevc_handler::get_encoder_properties(obs_properties_t* props, const A
 
 		{
 			auto p = obs_properties_add_list(grp, ST_KEY_PROFILE, D_TRANSLATE(S_CODEC_HEVC_PROFILE),
-											 OBS_COMBO_TYPE_LIST, OBS_COMBO_FORMAT_INT);
+											 OBS_COMBO_TYPE_LIST, OBS_COMBO_FORMAT_STRING);
 			obs_property_list_add_int(p, D_TRANSLATE(S_STATE_DEFAULT), -1);
-			streamfx::ffmpeg::tools::avoption_list_add_entries(context->priv_data, "profile", p, S_CODEC_HEVC_PROFILE);
+			streamfx::ffmpeg::tools::avoption_list_add_entries(
+				context->priv_data, "profile", [&p](const AVOption* opt) {
+					char buffer[1024];
+					snprintf(buffer, sizeof(buffer), "%s.%s\0", S_CODEC_HEVC_PROFILE, opt->name);
+					obs_property_list_add_string(p, D_TRANSLATE(buffer), opt->name);
+				});
 		}
 		{
 			auto p = obs_properties_add_list(grp, ST_KEY_TIER, D_TRANSLATE(S_CODEC_HEVC_TIER), OBS_COMBO_TYPE_LIST,
-											 OBS_COMBO_FORMAT_INT);
+											 OBS_COMBO_FORMAT_STRING);
 			obs_property_list_add_int(p, D_TRANSLATE(S_STATE_DEFAULT), -1);
-			streamfx::ffmpeg::tools::avoption_list_add_entries(context->priv_data, "tier", p, S_CODEC_HEVC_TIER);
+			streamfx::ffmpeg::tools::avoption_list_add_entries(context->priv_data, "tier", [&p](const AVOption* opt) {
+				char buffer[1024];
+				snprintf(buffer, sizeof(buffer), "%s.%s\0", S_CODEC_HEVC_TIER, opt->name);
+				obs_property_list_add_string(p, D_TRANSLATE(buffer), opt->name);
+			});
 		}
 		{
 			auto p = obs_properties_add_list(grp, ST_KEY_LEVEL, D_TRANSLATE(S_CODEC_HEVC_LEVEL), OBS_COMBO_TYPE_LIST,
-											 OBS_COMBO_FORMAT_INT);
-			obs_property_list_add_int(p, D_TRANSLATE(S_STATE_AUTOMATIC), 0);
-			streamfx::ffmpeg::tools::avoption_list_add_entries_unnamed(context->priv_data, "level", p,
-																	   [](const AVOption* opt) {
-																		   if (opt->default_val.i64 == 0)
-																			   return true;
-																		   return false;
-																	   });
+											 OBS_COMBO_FORMAT_STRING);
+
+			streamfx::ffmpeg::tools::avoption_list_add_entries(context->priv_data, "level", [&p](const AVOption* opt) {
+				if (opt->default_val.i64 == 0) {
+					obs_property_list_add_string(p, D_TRANSLATE(S_STATE_AUTOMATIC), "auto");
+				} else {
+					obs_property_list_add_string(p, opt->name, opt->name);
+				}
+			});
 		}
 	}
 
@@ -182,6 +190,40 @@ void streamfx::encoder::ffmpeg::handler::nvenc_hevc_handler::migrate(obs_data_t*
 																	 const AVCodec* codec, AVCodecContext* context)
 {
 	nvenc::migrate(settings, version, codec, context);
+
+	if (version < STREAMFX_MAKE_VERSION(0, 11, 1, 0)) {
+		// Profile
+		if (auto v = obs_data_get_int(settings, ST_KEY_PROFILE); v != -1) {
+			if (!obs_data_has_user_value(settings, ST_KEY_PROFILE))
+				v = 0;
+
+			std::map<int64_t, std::string> preset{
+				{0, "main"},
+				{1, "main10"},
+				{2, "rext"},
+			};
+			if (auto k = preset.find(v); k != preset.end()) {
+				obs_data_set_string(settings, ST_KEY_PROFILE, k->second.data());
+			}
+		}
+
+		// Tier
+		if (auto v = obs_data_get_int(settings, ST_KEY_TIER); v != -1) {
+			if (!obs_data_has_user_value(settings, ST_KEY_TIER))
+				v = 0;
+
+			std::map<int64_t, std::string> preset{
+				{0, "main"},
+				{1, "high"},
+			};
+			if (auto k = preset.find(v); k != preset.end()) {
+				obs_data_set_string(settings, ST_KEY_TIER, k->second.data());
+			}
+		}
+
+		// Level
+		obs_data_set_string(settings, ST_KEY_LEVEL, "auto");
+	}
 }
 
 bool nvenc_hevc_handler::supports_reconfigure(ffmpeg_factory* instance, bool& threads, bool& gpu, bool& keyframes)

--- a/source/ffmpeg/tools.cpp
+++ b/source/ffmpeg/tools.cpp
@@ -209,8 +209,8 @@ bool tools::avoption_exists(const void* obj, std::string_view name)
 	return false;
 }
 
-void tools::avoption_list_add_entries_unnamed(const void* obj, std::string_view unit, obs_property_t* prop,
-											  std::function<bool(const AVOption*)> filter)
+void tools::avoption_list_add_entries(const void* obj, std::string_view unit,
+									  std::function<void(const AVOption*)> inserter)
 {
 	for (const AVOption* opt = nullptr; (opt = av_opt_next(obj, opt)) != nullptr;) {
 		// Skip all irrelevant options.
@@ -225,38 +225,11 @@ void tools::avoption_list_add_entries_unnamed(const void* obj, std::string_view 
 		if (opt->flags & AV_OPT_FLAG_DEPRECATED)
 			continue;
 
-		if (filter && filter(opt))
-			continue;
-
-		// Generate name and add to list.
-		obs_property_list_add_int(prop, opt->name, opt->default_val.i64);
-	}
-}
-
-void tools::avoption_list_add_entries(const void* obj, std::string_view unit, obs_property_t* prop,
-									  std::string_view prefix, std::function<bool(const AVOption*)> filter)
-{
-	for (const AVOption* opt = nullptr; (opt = av_opt_next(obj, opt)) != nullptr;) {
-		// Skip all irrelevant options.
-		if (!opt->unit)
-			continue;
-		if (opt->unit != unit)
-			continue;
-		if (opt->name == unit)
-			continue;
-
-		// Skip any deprecated options.
-		if (opt->flags & AV_OPT_FLAG_DEPRECATED)
-			continue;
-
-		// Skip based on filter function.
-		if (filter && filter(opt))
-			continue;
-
-		// Generate name and add to list.
-		char buffer[1024];
-		snprintf(buffer, sizeof(buffer), "%s.%s\0", prefix.data(), opt->name);
-		obs_property_list_add_int(prop, D_TRANSLATE(buffer), opt->default_val.i64);
+		if (inserter) {
+			inserter(opt);
+		} else {
+			break;
+		}
 	}
 }
 

--- a/source/ffmpeg/tools.hpp
+++ b/source/ffmpeg/tools.hpp
@@ -85,10 +85,7 @@ namespace streamfx::ffmpeg::tools {
 
 	const char* avoption_name_from_unit_value(const void* obj, std::string_view unit, int64_t value);
 
-	void avoption_list_add_entries_unnamed(const void* obj, std::string_view unit, obs_property_t* prop,
-										   std::function<bool(const AVOption*)> filter = nullptr);
-
-	void avoption_list_add_entries(const void* obj, std::string_view unit, obs_property_t* prop,
-								   std::string_view prefix, std::function<bool(const AVOption*)> filter = nullptr);
+	void avoption_list_add_entries(const void* obj, std::string_view unit,
+								   std::function<void(const AVOption*)> inserter = nullptr);
 
 } // namespace streamfx::ffmpeg::tools


### PR DESCRIPTION
### Explain the Pull Request
Further improves support for different FFmpeg versions than 4.2 by making the settings themselves not rely on internal numbers, but names. This hopefully allows us to support any FFmpeg version for a while, and makes migration way easier.

### Related Issues
<!-- Is this PR related to another PR or Issue? List them here. -->
<!-- - #0000 Name of Issue -->
<!-- - #0001 Name of Issue -->

### Checklist
- [x] I will become the maintainer for this part of code.
- [x] I have tested this code on all supported Platforms.
