### PR TITLE
encoder-ffmpeg.cpp: Remove legacy API usage

### DIFF
--- a/source/encoders/encoder-ffmpeg.cpp
+++ b/source/encoders/encoder-ffmpeg.cpp
@@ -1180,7 +1180,7 @@ ffmpeg_manager::~ffmpeg_manager()
 void ffmpeg_manager::register_encoders()
 {
 	// Encoders
-#if FF_API_NEXT
+#if !FF_API_NEXT
 	void* iterator = nullptr;
 	for (const AVCodec* codec = av_codec_iterate(&iterator); codec != nullptr; codec = av_codec_iterate(&iterator)) {
 		// Only register encoders.

--- a/source/encoders/encoder-ffmpeg.cpp
+++ b/source/encoders/encoder-ffmpeg.cpp
@@ -1180,7 +1180,6 @@ ffmpeg_manager::~ffmpeg_manager()
 void ffmpeg_manager::register_encoders()
 {
 	// Encoders
-#if !FF_API_NEXT
 	void* iterator = nullptr;
 	for (const AVCodec* codec = av_codec_iterate(&iterator); codec != nullptr; codec = av_codec_iterate(&iterator)) {
 		// Only register encoders.
@@ -1195,22 +1194,6 @@ void ffmpeg_manager::register_encoders()
 			}
 		}
 	}
-#else
-	AVCodec* codec = nullptr;
-	for (codec = av_codec_next(codec); codec != nullptr; codec = av_codec_next(codec)) {
-		// Only register encoders.
-		if (!av_codec_is_encoder(codec))
-			continue;
-
-		if ((codec->type == AVMediaType::AVMEDIA_TYPE_AUDIO) || (codec->type == AVMediaType::AVMEDIA_TYPE_VIDEO)) {
-			try {
-				_factories.emplace(codec, std::make_shared<ffmpeg_factory>(codec));
-			} catch (const std::exception& ex) {
-				DLOG_ERROR("Failed to register encoder '%s': %s", codec->name, ex.what());
-			}
-		}
-	}
-#endif
 }
 
 void ffmpeg_manager::register_handler(std::string codec, std::shared_ptr<handler::handler> handler)


### PR DESCRIPTION
### Explain the Pull Request
The build breaks if compiling against newer versions of ffmpeg which do not define the FF_API_NEXT macro and have fully removed the av_codec_next() API. It would only make sense to use av_codec_next() if FF_API_NEXT is still defined, so I flipped the condition on the preprocessor statement.

From what it seems, this could be a latent bug. I'm not too familiar with how the CI/CD on this repo works, but depending on the version of ffmpeg it sources, this issue could show up in builds in the future.

### Checklist
- [x] I will become the maintainer for this part of code.
- [ ] I have tested this code on all supported Platforms.
  - [x] Linux
  - [ ] Windows
  - [ ] MacOS
