### PR TITLE
ffmpeg-encoder/dnxhr: Added Avid DNxHR Encoder based on FFmpeg

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -293,6 +293,7 @@ set(${PREFIX}ENABLE_ENCODER_FFMPEG ON CACHE BOOL "Enable FFmpeg Encoder integrat
 set(${PREFIX}ENABLE_ENCODER_FFMPEG_AMF ON CACHE BOOL "Enable AMF Encoder in FFmpeg.")
 set(${PREFIX}ENABLE_ENCODER_FFMPEG_NVENC ON CACHE BOOL "Enable NVENC Encoder in FFmpeg.")
 set(${PREFIX}ENABLE_ENCODER_FFMPEG_PRORES ON CACHE BOOL "Enable ProRes Encoder in FFmpeg.")
+set(${PREFIX}ENABLE_ENCODER_FFMPEG_DNXHR ON CACHE BOOL "Enable DNXHR Encoder in FFmpeg.")
 set(${PREFIX}ENABLE_ENCODER_AOM_AV1 ON CACHE BOOL "Enable AOM AV1 Encoder.")
 
 ## Filters
@@ -665,6 +666,9 @@ function(feature_encoder_ffmpeg RESOLVE)
 
 			# ProRes
 			is_feature_enabled(ENCODER_FFMPEG_PRORES T_CHECK)
+
+			# DNxHR
+			is_feature_enabled(ENCODER_FFMPEG_DNXHR T_CHECK)
 		endif()
 	elseif(T_CHECK)
 		set(REQUIRE_FFMPEG ON PARENT_SCOPE)
@@ -1315,6 +1319,8 @@ if(T_CHECK)
 		"source/encoders/codecs/h264.cpp"
 		"source/encoders/codecs/prores.hpp"
 		"source/encoders/codecs/prores.cpp"
+		"source/encoders/codecs/dnxhr.hpp"
+		"source/encoders/codecs/dnxhr.cpp"
 
 		# Encoders/Handlers
 		"source/encoders/handlers/handler.hpp"
@@ -1367,6 +1373,18 @@ if(T_CHECK)
 		)
 		list(APPEND PROJECT_DEFINITIONS
 			ENABLE_ENCODER_FFMPEG_PRORES
+		)
+		endif()
+
+	# DNxHR
+	is_feature_enabled(ENCODER_FFMPEG_DNXHR T_CHECK)
+	if(T_CHECK)
+		list(APPEND PROJECT_PRIVATE_SOURCE
+				"source/encoders/handlers/dnxhd_handler.hpp"
+				"source/encoders/handlers/dnxhd_handler.cpp"
+		)
+		list(APPEND PROJECT_DEFINITIONS
+				ENABLE_ENCODER_FFMPEG_DNXHR
 		)
 	endif()
 endif()

--- a/data/locale/en-US.ini
+++ b/data/locale/en-US.ini
@@ -526,3 +526,12 @@ Codec.ProRes.Profile.APCN="422 Standard (APCN)"
 Codec.ProRes.Profile.APCH="422 High Quality/HQ (APCH)"
 Codec.ProRes.Profile.AP4H="4444 High Quality/HQ (AP4H)"
 Codec.ProRes.Profile.AP4X="4444 Extreme Quality/XQ (AP4X)"
+
+# Codec: Avid DNxHR
+Codec.DNxHR.Profile="Profile"
+Codec.DNxHR.Profile.dnxhd="DNxHD"
+Codec.DNxHR.Profile.dnxhr_lb="DNxHR LB (4:2:2)"
+Codec.DNxHR.Profile.dnxhr_sq="DNxHR SQ (4:2:2)"
+Codec.DNxHR.Profile.dnxhr_hq="DNxHR HQ (4:2:2)"
+Codec.DNxHR.Profile.dnxhr_hqx="DNxHR HQX (4:2:2)"
+Codec.DNxHR.Profile.dnxhr_444="DNxHR 444 (4:4:4)"

--- a/source/encoders/codecs/dnxhr.cpp
+++ b/source/encoders/codecs/dnxhr.cpp
@@ -1,0 +1,1 @@
+#include "dnxhr.hpp"

--- a/source/encoders/codecs/dnxhr.hpp
+++ b/source/encoders/codecs/dnxhr.hpp
@@ -1,0 +1,29 @@
+// FFMPEG based DNxHR Video Encoder Integration for OBS Studio
+// Copyright (c) 2022 Carsten Braun <carsten@braun-cloud.de>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma once
+#include "common.hpp"
+
+// Codec: DNxHR
+#define S_CODEC_DNXHR "Codec.DNxHR"
+#define S_CODEC_DNXHR_PROFILE "Codec.DNxHR.Profile"
+
+namespace streamfx::encoder::codec::dnxhr {} // namespace streamfx::encoder::codec::dnxhr

--- a/source/encoders/encoder-ffmpeg.cpp
+++ b/source/encoders/encoder-ffmpeg.cpp
@@ -42,6 +42,10 @@
 #include "handlers/prores_aw_handler.hpp"
 #endif
 
+#ifdef ENABLE_ENCODER_FFMPEG_DNXHR
+#include "handlers/dnxhd_handler.hpp"
+#endif
+
 extern "C" {
 #pragma warning(push)
 #pragma warning(disable : 4244)
@@ -1169,6 +1173,9 @@ ffmpeg_manager::ffmpeg_manager() : _factories(), _handlers(), _debug_handler()
 #endif
 #ifdef ENABLE_ENCODER_FFMPEG_PRORES
 	register_handler("prores_aw", ::std::make_shared<handler::prores_aw_handler>());
+#endif
+#ifdef ENABLE_ENCODER_FFMPEG_DNXHR
+	register_handler("dnxhd", ::std::make_shared<handler::dnxhd_handler>());
 #endif
 }
 

--- a/source/encoders/handlers/dnxhd_handler.cpp
+++ b/source/encoders/handlers/dnxhd_handler.cpp
@@ -1,0 +1,108 @@
+#include "dnxhd_handler.hpp"
+#include <array>
+#include "../codecs/dnxhr.hpp"
+#include "ffmpeg/tools.hpp"
+#include "plugin.hpp"
+
+extern "C" {
+#include <obs-module.h>
+}
+
+using namespace streamfx::encoder::ffmpeg::handler;
+using namespace streamfx::encoder::codec::dnxhr;
+
+void dnxhd_handler::adjust_info(ffmpeg_factory* fac, const AVCodec*, std::string&, std::string& name, std::string&)
+{
+	//Most people don't know what VC3 is and only know it as DNx.
+	//Change name to make it easier to find.
+	name = "Avid DNxHR (via FFmpeg)";
+}
+
+void dnxhd_handler::override_colorformat(AVPixelFormat& target_format, obs_data_t* settings, const AVCodec* codec,
+										 AVCodecContext*)
+{
+	static const std::array<std::pair<const char*, AVPixelFormat>, static_cast<size_t>(5)> profile_to_format_map{
+		std::pair{"dnxhr_lb", AV_PIX_FMT_YUV422P}, std::pair{"dnxhr_sq", AV_PIX_FMT_YUV422P},
+		std::pair{"dnxhr_hq", AV_PIX_FMT_YUV422P}, std::pair{"dnxhr_hqx", AV_PIX_FMT_YUV422P10LE},
+		std::pair{"dnxhr_444", AV_PIX_FMT_YUV444P10LE}};
+
+	const char* selected_profile = obs_data_get_string(settings, S_CODEC_DNXHR_PROFILE);
+	for (auto kv : profile_to_format_map) {
+		if (strcmp(kv.first, selected_profile) == 0) {
+			target_format = kv.second;
+			return;
+		}
+	}
+
+	//Fallback for (yet) unknown formats
+	target_format = AV_PIX_FMT_YUV422P;
+}
+
+void dnxhd_handler::get_defaults(obs_data_t* settings, const AVCodec*, AVCodecContext*, bool)
+{
+	obs_data_set_default_string(settings, S_CODEC_DNXHR_PROFILE, "dnxhr_sq");
+}
+
+bool dnxhd_handler::has_keyframe_support(ffmpeg_factory* instance)
+{
+	return false;
+}
+
+bool dnxhd_handler::has_pixel_format_support(ffmpeg_factory* instance)
+{
+	return false;
+}
+
+inline const char* dnx_profile_to_display_name(const char* profile)
+{
+	char buffer[1024];
+	snprintf(buffer, sizeof(buffer), "%s.%s\0", S_CODEC_DNXHR_PROFILE, profile);
+	return D_TRANSLATE(buffer);
+}
+
+void dnxhd_handler::get_properties(obs_properties_t* props, const AVCodec* codec, AVCodecContext* context, bool)
+{
+	AVCodecContext* ctx = context;
+
+	//Create dummy context if null was passed to the function
+	if (!ctx) {
+		ctx = avcodec_alloc_context3(codec);
+		if (!ctx->priv_data) {
+			avcodec_free_context(&ctx);
+			return;
+		}
+	}
+	auto p = obs_properties_add_list(props, S_CODEC_DNXHR_PROFILE, D_TRANSLATE(S_CODEC_DNXHR_PROFILE),
+									 OBS_COMBO_TYPE_LIST, OBS_COMBO_FORMAT_STRING);
+
+	streamfx::ffmpeg::tools::avoption_list_add_entries(ctx->priv_data, "profile", [&p](const AVOption* opt) {
+		if (strcmp(opt->name, "dnxhd") == 0) {
+			//Do not show DNxHD profile as it is outdated and should not be used.
+			//It's also very picky about framerate and framesize combos, which makes it even less useful
+			return;
+		}
+
+		//ffmpeg returns the profiles for DNxHR from highest to lowest.
+		//Lowest to highest is what people usually expect.
+		//Therefore, new entries will always be inserted at the top, effectively reversing the list
+		obs_property_list_insert_string(p, 0, dnx_profile_to_display_name(opt->name), opt->name);
+	});
+
+	//Free context if we created it here
+	if (ctx && ctx != context) {
+		avcodec_free_context(&ctx);
+	}
+}
+
+void dnxhd_handler::update(obs_data_t* settings, const AVCodec* codec, AVCodecContext* context)
+{
+	const char* profile = obs_data_get_string(settings, S_CODEC_DNXHR_PROFILE);
+	av_opt_set(context, "profile", profile, AV_OPT_SEARCH_CHILDREN);
+}
+
+void dnxhd_handler::log_options(obs_data_t* settings, const AVCodec* codec, AVCodecContext* context)
+{
+	DLOG_INFO("[%s]   Avid DNxHR:", codec->name);
+	streamfx::ffmpeg::tools::print_av_option_string2(context, "profile", "    Profile",
+													 [](int64_t v, std::string_view o) { return std::string(o); });
+}

--- a/source/encoders/handlers/dnxhd_handler.hpp
+++ b/source/encoders/handlers/dnxhd_handler.hpp
@@ -1,0 +1,68 @@
+// FFMPEG based DNxHR Video Encoder Integration for OBS Studio
+// Copyright (c) 2022 Carsten Braun <carsten@braun-cloud.de>
+// Copyright (c) 2019 Michael Fabian Dirks <info@xaymar.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma once
+#include "handler.hpp"
+
+extern "C" {
+#pragma warning(push)
+#pragma warning(disable : 4244)
+#include <libavcodec/avcodec.h>
+#pragma warning(pop)
+}
+
+namespace streamfx::encoder::ffmpeg::handler {
+	class dnxhd_handler : public handler {
+		public:
+		virtual ~dnxhd_handler(){};
+
+		public /*factory*/:
+		virtual void adjust_info(ffmpeg_factory* factory, const AVCodec* codec, std::string& id, std::string& name,
+								 std::string& codec_id);
+
+		public /*factory*/:
+		void get_defaults(obs_data_t* settings, const AVCodec* codec, AVCodecContext* context, bool hw_encode) override;
+
+		virtual std::string_view get_help_url(const AVCodec* codec) override
+		{
+			return "https://github.com/Xaymar/obs-StreamFX/wiki/Encoder-FFmpeg-Avid-DNxHR";
+		};
+
+		public /*support tests*/:
+		virtual bool has_keyframe_support(ffmpeg_factory* instance) override;
+
+		public /*support tests*/:
+		bool has_pixel_format_support(ffmpeg_factory* instance) override;
+
+		public /*settings*/:
+		void get_properties(obs_properties_t* props, const AVCodec* codec, AVCodecContext* context,
+							bool hw_encode) override;
+
+		void update(obs_data_t* settings, const AVCodec* codec, AVCodecContext* context) override;
+
+		void log_options(obs_data_t* settings, const AVCodec* codec, AVCodecContext* context) override;
+
+		public /*instance*/:
+		void override_colorformat(AVPixelFormat& target_format, obs_data_t* settings, const AVCodec* codec,
+								  AVCodecContext* context) override;
+	};
+} // namespace streamfx::encoder::ffmpeg::handler


### PR DESCRIPTION
### Explain the Pull Request
Added encoder for Avid DNxHR for 8 and 10 bit formats (although OBS doesn't support 10bit - yet). 

- DNxHR LB (8bit)
- DNxHR SQ (8bit)
- DNxHR HQ (8bit)
- DNxHR HQX (10bit)
- DNxHR 444 (10bit)

This is an alternative to the existing ProRes encoder.

### Why is this necessary?
The default DNx encoder, that can be used through OBS' integrated FFmpeg output, cannot do proper 4:2:2 chroma as it is missing pixel format conversions from 4:4:4 to 4:2:0. Therefore, you could only record 4:2:0 as 4:2:2, which is not true 4:2:2, or 4:4:4 as 4:4:4 (DNxHR 444 10bit), which is massive in size and often unnecessary. 
OBS has no native 4:2:2 option (yet).

### Checklist
- [x] I will become the maintainer for this part of code.
- [ ] I have tested this code on all supported Platforms.
