### PR TITLE
templates/windows/installer: Implement `/Portable` installer flag for CLI users

### DIFF
--- a/templates/windows/installer.iss.in
+++ b/templates/windows/installer.iss.in
@@ -149,6 +149,24 @@ begin
 end;
 
 // ------------------------------------------------------------------------------------------------------------------ //
+function ParamExists(Name: String): Boolean;
+var
+	Idx: Integer;
+	Limit: Integer;
+	Param: String;
+begin
+	Limit := ParamCount()
+	for Idx := 1 to Limit do begin
+		Param := ParamStr(Idx);
+		if SameText(Param, '/' + Name) then begin
+			Result := True;
+			exit;
+		end;
+	end;
+	Result := False;
+end;
+
+// ------------------------------------------------------------------------------------------------------------------ //
 var
 	oModePageSystemChoice: TNewRadioButton;
 	oModePageUserChoice: TNewRadioButton;
@@ -190,9 +208,15 @@ procedure OnModePageSystemChoiceClick(Sender: TObject); forward;
 // ------------------------------------------------------------------------------------------------------------------ //
 function InitializeSetup(): Boolean;
 begin
-	bIsSystemMode := IsAdmin();
-	bIsUsermode := not IsAdmin();
-	bIsPortableMode := False;
+	if ParamExists('Portable') then begin
+		bIsSystemMode := False;
+		bIsUserMode := False;
+		bIsPortableMode := True;
+	end else begin
+		bIsSystemMode := IsAdmin();
+		bIsUserMode := not IsAdmin();
+		bIsPortableMode := False;
+	end;
 
 	Result := True;
 end;


### PR DESCRIPTION
### Explain the Pull Request
Implements a `/Portable` flag which will properly switch the Installer into Portable mode as expected when run from CLI.

#### Completion Checklist
- [ ] I have added myself to the Copyright and License headers and files.
- [ ] I will maintain this code in the future and have added myself to `CODEOWNERS`.
- I have tested this change on the following platforms:
  - [ ] MacOS 10.15
  - [ ] MacOS 11
  - [ ] MacOS 12
  - [ ] Ubuntu 20.04
  - [ ] Ubuntu 22.04
  - [x] Windows 10
  - [ ] Windows 11
