### PR TITLE
Don't show path selection for System & User mode

### DIFF
--- a/templates/windows/installer.iss.in
+++ b/templates/windows/installer.iss.in
@@ -219,7 +219,9 @@ end;
 function ShouldSkipPage(PageID: Integer): Boolean;
 begin
 	Result := False;
-	if (PageID = wpSelectComponents) then begin
+	if (PageID = wpSelectDir) then begin
+		Result := not IsPortableMode();
+	end else if (PageID = wpSelectComponents) then begin
 		Result := True;
 	end else if (PageID = wpSelectProgramGroup) then begin
 		Result := not WizardIsComponentSelected('startmenu');
@@ -261,27 +263,21 @@ function GetDefaultDirectory(Value: String): String;
 var
 	sPath: String;
 begin
-	// If a path was given as an argument, use it.
-	if (Value <> '') then begin
-		Result := Value;
-		exit;
-	end;
-
-	// Otherwise, try and figure out where the previous installation of the same type went to.
-	if (RegQueryStringValue(HKA64, AppRegistryKey(), 'InstallLocation', sPath)) then begin
-		Result := sPath;
-		exit;
-	end;
-
 	// In all other cases, change depending on the chosen install method.
 	if (IsSystemMode()) then begin
 		// Default to ProgramData/obs-studio/@PROJECT_NAME@
 		Result := ExpandConstant('{commonappdata}\obs-studio\plugins\@PROJECT_NAME@');
-	end else begin 
-		Result := ExpandConstant('{userpf}\obs-studio\plugins\@PROJECT_NAME@')
-	end;
+	end else if (IsUserMode()) then begin 
+		Result := ExpandConstant('{userpf}\obs-studio\plugins\@PROJECT_NAME@');
+	end else begin
+		// If a path was given as an argument, use it.
+		if (Value <> '') then begin
+			Result := Value;
+			exit;
+		end;
 
-	exit;
+		Result := ExpandConstant('{userdesktop}\obs-studio');
+	end;
 end;
 
 // ------------------------------------------------------------------------------------------------------------------ //

--- a/templates/windows/installer.iss.in
+++ b/templates/windows/installer.iss.in
@@ -101,40 +101,13 @@ type
 	WPARAM = UINT_PTR;
 	LPARAM = INT_PTR;
 	LRESULT = INT_PTR;
-	LSTATUS = DWord;
-	LPCVOID = UINT_PTR;
-	HKEY = DWord;
-	PHKEY = UINT_PTR;
 
 const
 	SMTO_ABORTIFHUNG = 2;
 	WM_WININICHANGE = $001A;
 	WM_SETTINGCHANGE = WM_WININICHANGE;
-//	HKEY_CURRENT_USER = $80000001;
-//	HKEY_LOCAL_MACHINE = $80000002;
 
-function advapi32_RegSetKeyValue(
-	hKey: HKEY;
-	lpSubKey: string;
-	lpValueName: string;
-	dwType: DWord;
-	lpData: string;
-	dwData: DWord
-): LRESULT;
-	external 'RegSetKeyValue{#AW}@advapi32.dll stdcall';
-
-function SetRegistryKeyValueString(
-	Root: HKEY;
-	Key: string;
-	Name: string;
-	Value: string
-): BOOL;
-begin
-	advapi32_RegSetKeyValue(Root, Key, Name, 2, Value, Length(Value) * 2);
-	Result := True;
-end;
-
-function user32_SendTextMessageTimeout(
+function user32_SendTextMessageTimeoutA(
 	hWnd: HWND;
 	Msg: UINT;
 	wParam: WPARAM;
@@ -150,7 +123,7 @@ var
 	MsgResult: DWORD;
 begin
 	S := 'Environment';
-	user32_SendTextMessageTimeout(HWND_BROADCAST, WM_SETTINGCHANGE, 0,
+	user32_SendTextMessageTimeoutA(HWND_BROADCAST, WM_SETTINGCHANGE, 0,
 		PAnsiChar(S), SMTO_ABORTIFHUNG, 5000, MsgResult);
 end;
 
@@ -272,11 +245,11 @@ begin
 	if (IsUserMode()) then begin
 		sPluginsPath := ExpandConstant('{userpf}\obs-studio\plugins\%module%\bin\');
 		StringChangeEx(sPluginsPath, '\', '/', True);
-		SetRegistryKeyValueString(HKEY_CURRENT_USER, 'Environment', 'OBS_PLUGINS_PATH', sPluginsPath);
+		RegWriteExpandStringValue(HKEY_CURRENT_USER, 'Environment', 'OBS_PLUGINS_PATH', sPluginsPath);
 
 		sPluginsDataPath := ExpandConstant('{userpf}\obs-studio\plugins\%module%\data\');
 		StringChangeEx(sPluginsDataPath, '\', '/', True);
-		SetRegistryKeyValueString(HKEY_CURRENT_USER, 'Environment', 'OBS_PLUGINS_DATA_PATH', sPluginsDataPath);
+		RegWriteExpandStringValue(HKEY_CURRENT_USER, 'Environment', 'OBS_PLUGINS_DATA_PATH', sPluginsDataPath);
 
 		RefreshEnvironment();
 	end;

--- a/templates/windows/installer.iss.in
+++ b/templates/windows/installer.iss.in
@@ -57,7 +57,8 @@ UsePreviousAppDir=no
 DisableDirPage=no
 DirExistsWarning=no
 DefaultDirName={code:GetDefaultDirectory}
-AppendDefaultDirName=no
+AppendDefaultDirName=yes
+DisableProgramGroupPage=no
 DefaultGroupName={#MyAppName}
 AppendDefaultGroupName=yes
 


### PR DESCRIPTION
### Explain the Pull Request
The directory selection for System & User mode only serves to confuse end users, as the default is already correct in every possible case. We rely on Windows-managed paths, which are nearly impossible to change after Windows has been installed, so this directory choice should only be offered for Portable users.

Additionally, we should use the built in RegWriteExpandStringValue instead of a custom call.

#### Completion Checklist
- [ ] I have added myself to the Copyright and License headers and files.
- [ ] I will maintain this code in the future and have added myself to `CODEOWNERS`.
- I have tested this change on the following platforms:
  - [ ] MacOS 10.15
  - [ ] MacOS 11
  - [ ] MacOS 12
  - [ ] Ubuntu 20.04
  - [ ] Ubuntu 22.04
  - [x] Windows 10
  - [ ] Windows 11
