### PR TITLE
encoder/ffmpeg: Remove usage of `avcodec_close`

### DIFF
--- a/source/encoders/encoder-ffmpeg.cpp
+++ b/source/encoders/encoder-ffmpeg.cpp
@@ -180,7 +180,6 @@ ffmpeg_instance::~ffmpeg_instance()
 		}
 
 		// Close and free context.
-		avcodec_close(_context);
 		avcodec_free_context(&_context);
 	}
 


### PR DESCRIPTION
### Explain the Pull Request
This functionality has been deprecated by FFmpeg.

#### Completion Checklist
- [x] I have added myself to the Copyright and License headers and files.
- [ ] I will maintain this code in the future and have added myself to `CODEOWNERS`.
- I have tested this change on the following platforms:
  - [ ] MacOS 10.15
  - [ ] MacOS 11
  - [ ] MacOS 12
  - [ ] Ubuntu 20.04
  - [ ] Ubuntu 22.04
  - [x] Windows 10
  - [ ] Windows 11
