### PR TITLE
Fix some Use-After-Free issues with the D3D11 integration with FFmpeg

### DIFF
--- a/source/ffmpeg/hwapi/d3d11.cpp
+++ b/source/ffmpeg/hwapi/d3d11.cpp
@@ -188,10 +188,7 @@ std::shared_ptr<AVFrame> d3d11_instance::allocate_frame(AVBufferRef* frames)
 	auto gctx = streamfx::obs::gs::context();
 
 	// Allocate a frame.
-	auto frame = std::shared_ptr<AVFrame>(av_frame_alloc(), [](AVFrame* frame) {
-		av_frame_unref(frame);
-		av_frame_free(&frame);
-	});
+	auto frame = std::shared_ptr<AVFrame>(av_frame_alloc(), [](AVFrame* frame) { av_frame_free(&frame); });
 
 	// Create the necessary buffers.
 	if (av_hwframe_get_buffer(frames, frame.get(), 0) < 0) {

--- a/source/ffmpeg/hwapi/d3d11.hpp
+++ b/source/ffmpeg/hwapi/d3d11.hpp
@@ -62,7 +62,7 @@ namespace streamfx::ffmpeg::hwapi {
 		ATL::CComPtr<ID3D11DeviceContext> _context;
 
 		public:
-		d3d11_instance(ATL::CComPtr<ID3D11Device> device, ATL::CComPtr<ID3D11DeviceContext> context);
+		d3d11_instance(ATL::CComPtr<ID3D11Device> device);
 		virtual ~d3d11_instance();
 
 		virtual AVBufferRef* create_device_context() override;


### PR DESCRIPTION
### Explain the Pull Request
The D3D11 backend was incorrectly double-freeing some objects.

#### Completion Checklist
- [x] I have added myself to the Copyright and License headers and files.
- [ ] I will maintain this code in the future and have added myself to `CODEOWNERS`.
- I have tested this change on the following platforms:
  - [ ] MacOS 10.15
  - [ ] MacOS 11
  - [ ] MacOS 12
  - [ ] Ubuntu 20.04
  - [ ] Ubuntu 22.04
  - [x] Windows 10
  - [ ] Windows 11
