### PR TITLE
plugin: Only initialize GLAD on OpenGL graphics backend

### DIFF
--- a/source/plugin.cpp
+++ b/source/plugin.cpp
@@ -116,7 +116,9 @@ MODULE_EXPORT bool obs_module_load(void)
 		// Initialize GLAD (OpenGL)
 		{
 			streamfx::obs::gs::context gctx{};
-			_streamfx_gfx_opengl = streamfx::gfx::opengl::get();
+			if (gs_get_device_type() == GS_DEVICE_OPENGL) {
+				_streamfx_gfx_opengl = streamfx::gfx::opengl::get();
+			}
 		}
 
 #ifdef ENABLE_NVIDIA_CUDA


### PR DESCRIPTION
### Explain the Pull Request
Only initializing GLAD when OpenGL is used should remove some graphics debugging warnings of having multiple APIs loaded at the same time. No real effect on performance or stability though.
<!-- Describe the PR in as much detail as possible. If possible include example images, videos and documents, and explain why it is necessary. If this is related to a discussion or issue, please also link them. -->

#### Completion Checklist
- [ ] I have added myself to the Copyright and License headers and files.
- [x] I will maintain this code in the future and have added myself to `CODEOWNERS`.
- I have tested this change on the following platforms:
  - [ ] MacOS 10.15
  - [ ] MacOS 11
  - [ ] MacOS 12
  - [ ] Ubuntu 20.04
  - [ ] Ubuntu 22.04
  - [ ] Windows 10
  - [x] Windows 11
