### PR TITLE
#818 Don't self-reference when masking is enabled

### DIFF
--- a/source/filters/filter-blur.cpp
+++ b/source/filters/filter-blur.cpp
@@ -377,7 +377,7 @@ void blur_instance::video_tick(float)
 		if (_mask.source.name_old != _mask.source.name) {
 			try {
 				_mask.source.source_texture = std::make_shared<streamfx::gfx::source_texture>(
-					::streamfx::obs::weak_source(_mask.source.name), ::streamfx::obs::weak_source(_self));
+					::streamfx::obs::source{_mask.source.name}, ::streamfx::obs::source{_self, false});
 				_mask.source.is_scene = (obs_scene_from_source(_mask.source.source_texture->get_object()) != nullptr);
 				_mask.source.name_old = _mask.source.name;
 			} catch (...) {

--- a/source/gfx/gfx-source-texture.cpp
+++ b/source/gfx/gfx-source-texture.cpp
@@ -30,8 +30,8 @@ streamfx::gfx::source_texture::~source_texture()
 	}
 }
 
-streamfx::gfx::source_texture::source_texture(streamfx::obs::weak_source child, streamfx::obs::weak_source parent)
-	: _parent(parent.lock()), _child(child.lock())
+streamfx::gfx::source_texture::source_texture(streamfx::obs::source child, streamfx::obs::source parent)
+	: _parent(parent), _child(child)
 {
 	// Verify that 'child' and 'parent' exist.
 	if (!_child || !_parent) {
@@ -39,9 +39,9 @@ streamfx::gfx::source_texture::source_texture(streamfx::obs::weak_source child, 
 	}
 
 	// Verify that 'child' does not contain 'parent'.
-	if (::streamfx::obs::tools::source_find_source(_child, _parent)) {
+	if (::streamfx::obs::tools::source_find_source(child, parent)) {
 		throw std::runtime_error("Child contains Parent");
-	} else if (!obs_source_add_active_child(_parent.get(), _child.get())) {
+	} else if (!obs_source_add_active_child(parent, child)) {
 		throw std::runtime_error("Child contains Parent");
 	}
 

--- a/source/gfx/gfx-source-texture.hpp
+++ b/source/gfx/gfx-source-texture.hpp
@@ -19,6 +19,7 @@
 #include "common.hpp"
 #include "obs/gs/gs-rendertarget.hpp"
 #include "obs/gs/gs-texture.hpp"
+#include "obs/obs-source.hpp"
 #include "obs/obs-weak-source.hpp"
 
 #include "warning-disable.hpp"
@@ -34,7 +35,7 @@ namespace streamfx::gfx {
 
 		public:
 		~source_texture();
-		source_texture(streamfx::obs::weak_source child, streamfx::obs::weak_source parent);
+		source_texture(streamfx::obs::source child, streamfx::obs::source parent);
 
 		public /*copy*/:
 		source_texture(source_texture const& other)            = delete;


### PR DESCRIPTION
### Explain the Pull Request
Fixes a double-addref performed by anything that uses source_texture, a legacy class for rendering sources to texture.
<!-- Describe the PR in as much detail as possible. If possible include example images, videos and documents, and explain why it is necessary. If this is related to a discussion or issue, please also link them. -->

#### Completion Checklist
<!-- Check all items that apply. Don't lie here, we'll know the moment we verify this. -->
- [ ] This has been tested on the following platforms: <!-- REQUIRED (at least one) -->
  - [ ] MacOS 10.15
  - [ ] MacOS 11
  - [ ] MacOS 12
  - [ ] Ubuntu 20.04
  - [ ] Ubuntu 22.04
  - [ ] Windows 10
  - [x] Windows 11
- [ ] The copyright headers and license files have been updated. <!-- REQUIRED -->
- [ ] I will maintain this for the forseeable future, and have added myself to `CODEOWNERS`. <!-- REQUIRED for content or feature additions -->
