### PR TITLE
Create diff_mask.effect

### DIFF
--- a/data/examples/shaders/filter/diff_mask.effect
+++ b/data/examples/shaders/filter/diff_mask.effect
@@ -1,0 +1,91 @@
+// Written by f3flight in 2022
+//
+// I wrote this just to test the idea.
+//
+// This filter is a Difference Mask - basically allows masking (and soft-masking, and negative-masking) based on RGB difference
+// between Mask (file for ex.) pixels and Source pixels.
+// Example use-case: instead of using green screen, ensure that any foreground objects have different color than background,
+// then take a screnshot of only background and use as Mask.
+// For best results, disable automatic exposure / wb / etc in your camera to have consistentcy between screenshot and live feed,
+// and have enough light to reduce noise.
+//
+// Enjoy =)
+//
+//------------------------------------------------------------------------------
+// Uniforms
+//------------------------------------------------------------------------------
+uniform float4x4 ViewProj<
+	bool automatic = true;
+>;
+
+uniform float4 ViewSize<
+	bool automatic = true;
+>;
+
+uniform texture2d InputA<
+	bool automatic = true;
+>;
+
+uniform texture2d Mask;
+
+uniform float lower_threshold<
+	string name = "Lower Threshold";
+	string field_type = "slider";
+	float minimum = 0.0;
+	float maximum = 1.0;
+	float step = 0.01;
+	float scale = 1;
+> = 0.1;
+
+uniform float upper_threshold<
+	string name = "Upper Threshold";
+	string field_type = "slider";
+	float minimum = 0.0;
+	float maximum = 1.0;
+	float step = 0.01;
+	float scale = 1;
+> = 0.3;
+
+//------------------------------------------------------------------------------
+// Structs
+//------------------------------------------------------------------------------
+struct VertFragData {
+	float4 pos : POSITION;
+	float2 uv  : TEXCOORD0;
+};
+
+//------------------------------------------------------------------------------
+// Samplers
+//------------------------------------------------------------------------------
+sampler_state DefaultSampler {
+	Filter    = Point;
+	AddressU  = Clamp;
+	AddressV  = Clamp;
+};
+
+//------------------------------------------------------------------------------
+// Functionality
+//------------------------------------------------------------------------------
+VertFragData VSDefault(VertFragData vtx) {
+	vtx.pos = mul(float4(vtx.pos.xyz, 1.0), ViewProj);
+	return vtx;
+};
+
+float4 PSDefault(VertFragData vtx) : TARGET {
+	float4 source = InputA.Sample(DefaultSampler, vtx.uv);
+	float3 mask_rgb = Mask.Sample(DefaultSampler, vtx.uv).rgb;
+	float3 diff = abs(source.rgb - mask_rgb);
+	float diff_flat = (diff.r + diff.g + diff.b) / 3;
+	float mask = smoothstep(lower_threshold, upper_threshold, diff_flat);
+	source.a = mask;
+	return source;
+}
+
+technique Draw
+{
+	pass
+	{
+		vertex_shader = VSDefault(vtx);
+		pixel_shader  = PSDefault(vtx);
+	}
+}

--- a/data/examples/shaders/filter/diff_mask.effect
+++ b/data/examples/shaders/filter/diff_mask.effect
@@ -11,6 +11,31 @@
 //
 // Enjoy =)
 //
+// Copyright 2022 Dmitrii Sutiagin <f3flight@gmail.com>
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+//	this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//	this list of conditions and the following disclaimer in the documentation
+//	and/or other materials provided with the distribution.
+// 3. Neither the name of the copyright holder nor the names of its contributors
+//	may be used to endorse or promote products derived from this software
+//	without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
 //------------------------------------------------------------------------------
 // Uniforms
 //------------------------------------------------------------------------------


### PR DESCRIPTION
Add a filter which does per-pixel masking based on difference between Mask image and input (camera) image.

### Explain the Pull Request
This is just a simple mask filter which can help people w/o green screen who don't want or can't use NVidia BG remover or other methods, or if they want to play with the mask and have some weird effects =)

#### Completion Checklist
<!-- Check all items that apply. Don't lie here, we'll know the moment we verify this. -->
- [ ] This has been tested on the following platforms: <!-- REQUIRED (at least one) -->
  - [ ] MacOS 10.15
  - [ ] MacOS 11
  - [ ] MacOS 12
  - [ ] Ubuntu 20.04
  - [ ] Ubuntu 22.04
  - [ ] Windows 10
  - [X] Windows 11
- [X] The copyright headers and license files have been updated. <!-- REQUIRED -->
- [ ] I will maintain this for the forseeable future, and have added myself to `CODEOWNERS`. <!-- REQUIRED for content or feature additions -->
