### PR TITLE
code: Initialize worker count to 0

### DIFF
--- a/source/util/util-threadpool.cpp
+++ b/source/util/util-threadpool.cpp
@@ -1,4 +1,5 @@
 // Copyright (C) 2020-2022 Michael Fabian Dirks
+// Copyright (C) 2023 tt2468
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -133,7 +134,7 @@ streamfx::util::threadpool::threadpool::~threadpool()
 }
 
 streamfx::util::threadpool::threadpool::threadpool(size_t minimum, size_t maximum)
-	: _limits{minimum, maximum}, _workers_lock(), _workers(), _tasks_lock(), _tasks_cv(), _tasks()
+	: _limits{minimum, maximum}, _workers_lock(), _worker_count(0), _workers(), _tasks_lock(), _tasks_cv(), _tasks()
 {
 	// Spawn the minimum number of threads.
 	spawn(_limits.first);


### PR DESCRIPTION
### Explain the Pull Request
Many platforms (and/or kernels) don't zero memory before it is acquired, resulting in uninitialized memory being used to store critical content. This made the threadpool assume it had an infinite number of threads to work with, despite actually having spawned none.

Fixes #1017

#### Completion Checklist
<!-- Check all items that apply. Don't lie here, we'll know the moment we verify this. -->
- [x] This has been tested on the following platforms: <!-- REQUIRED (at least one) -->
  - [ ] MacOS 10.15
  - [ ] MacOS 11
  - [x] MacOS 12
  - [ ] Ubuntu 20.04
  - [x] Ubuntu 22.04
  - [ ] Windows 10
  - [x] Windows 11
- [x] The copyright headers and license files have been updated. <!-- REQUIRED -->
- [ ] I will maintain this for the forseeable future, and have added myself to `CODEOWNERS`. <!-- REQUIRED for content or feature additions -->
