### PR TITLE
cmake: Fix temporary disables happening permanently

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -438,7 +438,7 @@ macro(is_feature_enabled FEATURE OUTPUT)
 endmacro()
 
 macro(set_feature_disabled FEATURE DISABLED)
-	set(${PREFIX}DISABLE_${FEATURE} ${DISABLED} CACHE INTERNAL "" FORCE)
+	set(${PREFIX}DISABLE_${FEATURE} ${DISABLED})
 endmacro()
 
 # Features


### PR DESCRIPTION
### Explain the Pull Request
Fixes an issue in CMake causing the feature disable to stick around permanently.
<!-- Describe the PR in as much detail as possible. If possible include example images, videos and documents, and explain why it is necessary. If this is related to a discussion or issue, please also link them. -->

#### Completion Checklist
<!-- Check all items that apply. Don't lie here, we'll know the moment we verify this. -->
- [ ] This has been tested on the following platforms: <!-- REQUIRED (at least one) -->
  - [ ] MacOS 10.15
  - [ ] MacOS 11
  - [ ] MacOS 12
  - [ ] Ubuntu 20.04
  - [ ] Ubuntu 22.04
  - [ ] Windows 10
  - [ ] Windows 11
- [ ] The copyright headers and license files have been updated. <!-- REQUIRED -->
- [ ] I will maintain this for the forseeable future, and have added myself to `CODEOWNERS`. <!-- REQUIRED for content or feature additions -->
