### PR TITLE
util/library: Allow loading of obs_module_t

### DIFF
--- a/source/util/util-library.hpp
+++ b/source/util/util-library.hpp
@@ -7,20 +7,27 @@
 #include <filesystem>
 #include <memory>
 #include <string_view>
+
+#include <obs.h>
 #include "warning-enable.hpp"
 
 namespace streamfx::util {
 	class library {
 		void* _library;
+		bool  _owner;
 
 		public:
 		library(std::filesystem::path file);
+		library(obs_module_t* library);
 		~library();
 
 		void* load_symbol(std::string_view name);
 
+		public:
 		static std::shared_ptr<::streamfx::util::library> load(std::filesystem::path file);
 
 		static std::shared_ptr<::streamfx::util::library> load(std::string_view name);
+
+		static std::shared_ptr<::streamfx::util::library> load(obs_module_t* instance);
 	};
 } // namespace streamfx::util


### PR DESCRIPTION
### Explain the Pull Request
Allows passing an obs_module_t to util::library::load in order to use a libOBS module as a library for functions. Aids in implementing other features, such as browser source widgets.

#### Completion Checklist
<!-- Check all items that apply. Don't lie here, we'll know the moment we verify this. -->
- [x] This has been tested on the following platforms: <!-- REQUIRED (at least one) -->
  - [ ] MacOS 10.15
  - [ ] MacOS 11
  - [ ] MacOS 12
  - [ ] Ubuntu 20.04
  - [ ] Ubuntu 22.04
  - [ ] Windows 10
  - [x] Windows 11
- [ ] The copyright headers and license files have been updated. <!-- REQUIRED -->
- [ ] I will maintain this for the forseeable future, and have added myself to `CODEOWNERS`. <!-- REQUIRED for content or feature additions -->
