### PR TITLE
Fix version detection and comparison issue

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -151,99 +151,74 @@ if(EXISTS "${CMAKE_CURRENT_LIST_DIR}/.git")
 	)
 
 	if(EXISTS "${GIT}")
-		# Determine the version by exist tag match.
-		execute_process(COMMAND "${GIT}" tag "--sort=-v:refname" "--points-at" HEAD WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR} RESULT_VARIABLE GIT_RESULT OUTPUT_VARIABLE GIT_OUTPUT ERROR_VARIABLE GIT_ERROR OUTPUT_STRIP_TRAILING_WHITESPACE ERROR_STRIP_TRAILING_WHITESPACE ERROR_QUIET)
+		# Try and calculate the exist version using git.
+		execute_process(COMMAND "${GIT}" describe --tags --long --abbrev=8 HEAD WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR} RESULT_VARIABLE GIT_RESULT OUTPUT_VARIABLE GIT_OUTPUT ERROR_VARIABLE GIT_ERROR OUTPUT_STRIP_TRAILING_WHITESPACE ERROR_STRIP_TRAILING_WHITESPACE ERROR_QUIET)
 		if((GIT_RESULT EQUAL 0) AND (NOT "${GIT_OUTPUT}" STREQUAL ""))
-			# Some minor string editing so the output conforms to SemVer 2.0.0.
-			string(REGEX REPLACE "[\r\n]+.*" "" GIT_OUTPUT "${GIT_OUTPUT}")
+			# Result will be MAJOR.MINOR.PATCH-TWEAK-gHASH
+			string(REPLACE "-" ";" GIT_OUTPUT "${GIT_OUTPUT}")
+			string(REPLACE "." ";" GIT_OUTPUT "${GIT_OUTPUT}")
 
-			# Parse as SemVer 2.0.0
-			version(PARSE GIT_OUTPUT "${GIT_OUTPUT}" REQUIRE "PATCH;TWEAK")
-			if(GIT_OUTPUT_PRERELEASE)
-				string(SUBSTRING "${GIT_OUTPUT_PRERELEASE}" 1 -1 GIT_OUTPUT_TWEAK)
-				string(SUBSTRING "${GIT_OUTPUT_PRERELEASE}" 0 1 GIT_OUTPUT_PRERELEASE)
+			# Split into components
+			list(GET GIT_OUTPUT 0 GIT_OUTPUT_MAJOR)
+			list(GET GIT_OUTPUT 1 GIT_OUTPUT_MINOR)
+			list(GET GIT_OUTPUT 2 GIT_OUTPUT_PATCH)
+			list(GET GIT_OUTPUT 3 GIT_OUTPUT_TWEAK)
+			list(GET GIT_OUTPUT 4 GIT_OUTPUT_BUILD)
 
-				if(NOT GIT_OUTPUT_TWEAK STREQUAL GIT_OUTPUT_TWEAK)
-					message(WARNING "'git' tag mismatches detected version: '${GIT_OUTPUT_TWEAK}' != '${GIT_OUTPUT_TWEAK}'.")
-				endif()
-			endif()
-
-			# Update our global version.
-			version(GENERATE _VERSION COMPRESS
-				MAJOR "${GIT_OUTPUT_MAJOR}"
-				MINOR "${GIT_OUTPUT_MINOR}"
-				PATCH "${GIT_OUTPUT_PATCH}"
-				TWEAK "${GIT_OUTPUT_TWEAK}"
-				PRERELEASE "${GIT_OUTPUT_PRERELEASE}"
-				BUILD "${_VERSION_BUILD}"
-				REQUIRE "PATCH;TWEAK"
-			)
-		else()
-			# Try and calculate the exist version using git.
-			execute_process(COMMAND "${GIT}" describe --tags --long --abbrev=8 HEAD WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR} RESULT_VARIABLE GIT_RESULT OUTPUT_VARIABLE GIT_OUTPUT ERROR_VARIABLE GIT_ERROR OUTPUT_STRIP_TRAILING_WHITESPACE ERROR_STRIP_TRAILING_WHITESPACE ERROR_QUIET)
-			if((GIT_RESULT EQUAL 0) AND (NOT "${GIT_OUTPUT}" STREQUAL ""))
-				# Result will be MAJOR.MINOR.PATCH-TWEAK-gHASH
-				string(REPLACE "-" ";" GIT_OUTPUT "${GIT_OUTPUT}")
-				string(REPLACE "." ";" GIT_OUTPUT "${GIT_OUTPUT}")
-
-				# Split into components
-				list(GET GIT_OUTPUT 0 GIT_OUTPUT_MAJOR)
-				list(GET GIT_OUTPUT 1 GIT_OUTPUT_MINOR)
-				list(GET GIT_OUTPUT 2 GIT_OUTPUT_PATCH)
-				list(GET GIT_OUTPUT 3 GIT_OUTPUT_TWEAK)
-				list(GET GIT_OUTPUT 4 GIT_OUTPUT_BUILD)
-
-				# Special case: Tag contains prerelease
-				if(GIT_OUTPUT_PATCH MATCHES "([0-9]+)([a-zA-Z]+)([0-9]*)")
-					# Patch requires special parsing.
-					set(GIT_OUTPUT_PATCH "${CMAKE_MATCH_1}")
-					MATH(EXPR GIT_OUTPUT_TWEAK "${GIT_OUTPUT_TWEAK} + ${CMAKE_MATCH_3}")
-
-					# Modify the global version
-					version(MODIFY _VERSION "${_VERSION}" COMPRESS
-						MAJOR "${GIT_OUTPUT_MAJOR}"
-						MINOR "${GIT_OUTPUT_MINOR}"
-						PATCH "${GIT_OUTPUT_PATCH}"
-						TWEAK "${GIT_OUTPUT_TWEAK}"
-						BUILD "${GIT_OUTPUT_BUILD}"
-						PRERELEASE "a"
-						REQUIRE "PATCH;TWEAK"
-					)
+			# Special case: Tag contains prerelease
+			if(GIT_OUTPUT_PATCH MATCHES "([0-9]+)([a-zA-Z]+)([0-9]*)")
+				# Patch requires special parsing.
+				set(GIT_OUTPUT_PATCH "${CMAKE_MATCH_1}")
+				if(CMAKE_MATCH_3 GREATER 0)
+					set(GIT_OUTPUT_PRERELEASE "${CMAKE_MATCH_2}")
 				else()
-					# Modify the global version
-					version(MODIFY _VERSION "${_VERSION}" COMPRESS
-						MAJOR "${GIT_OUTPUT_MAJOR}"
-						MINOR "${GIT_OUTPUT_MINOR}"
-						PATCH "${GIT_OUTPUT_PATCH}"
-						TWEAK "${GIT_OUTPUT_TWEAK}"
-						BUILD "${GIT_OUTPUT_BUILD}"
-						PRERELEASE "a"
-						REQUIRE "PATCH;TWEAK"
-					)
+					set(GIT_OUTPUT_PRERELEASE "a")
 				endif()
+				MATH(EXPR GIT_OUTPUT_TWEAK "${GIT_OUTPUT_TWEAK} + ${CMAKE_MATCH_3}")
+
+				# Modify the global version
+				version(MODIFY _VERSION "${_VERSION}" COMPRESS
+					MAJOR "${GIT_OUTPUT_MAJOR}"
+					MINOR "${GIT_OUTPUT_MINOR}"
+					PATCH "${GIT_OUTPUT_PATCH}"
+					TWEAK "${GIT_OUTPUT_TWEAK}"
+					BUILD "${GIT_OUTPUT_BUILD}"
+					PRERELEASE "${GIT_OUTPUT_PRERELEASE}"
+					REQUIRE "PATCH;TWEAK"
+				)
 			else()
-				execute_process(COMMAND "${GIT}" rev-list --count HEAD WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR} RESULT_VARIABLE GIT_RESULT OUTPUT_VARIABLE GIT_OUTPUT ERROR_VARIABLE GIT_ERROR OUTPUT_STRIP_TRAILING_WHITESPACE ERROR_STRIP_TRAILING_WHITESPACE ERROR_QUIET)
-				message(STATUS "GIT=${GIT_RESULT},${GIT_OUTPUT},${GIT_ERROR}")
+				# Modify the global version
+				version(MODIFY _VERSION "${_VERSION}" COMPRESS
+					MAJOR "${GIT_OUTPUT_MAJOR}"
+					MINOR "${GIT_OUTPUT_MINOR}"
+					PATCH "${GIT_OUTPUT_PATCH}"
+					TWEAK "${GIT_OUTPUT_TWEAK}"
+					BUILD "${GIT_OUTPUT_BUILD}"
+					PRERELEASE "a"
+					REQUIRE "PATCH;TWEAK"
+				)
+			endif()
+		else()
+			execute_process(COMMAND "${GIT}" rev-list --count HEAD WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR} RESULT_VARIABLE GIT_RESULT OUTPUT_VARIABLE GIT_OUTPUT ERROR_VARIABLE GIT_ERROR OUTPUT_STRIP_TRAILING_WHITESPACE ERROR_STRIP_TRAILING_WHITESPACE ERROR_QUIET)
+			if((GIT_RESULT EQUAL 0) AND (NOT "${GIT_OUTPUT}" STREQUAL ""))
+				version(MODIFY _VERSION "${_VERSION}" COMPRESS
+					TWEAK "${GIT_OUTPUT}"
+					PRERELEASE "a"
+					REQUIRE "PATCH;TWEAK"
+				)
+
+				# Determine the build using git.
+				execute_process(COMMAND "${GIT}" log -1 "--pretty=format:g%h" --abbrev=8 HEAD WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR} RESULT_VARIABLE GIT_RESULT OUTPUT_VARIABLE GIT_OUTPUT ERROR_VARIABLE GIT_ERROR OUTPUT_STRIP_TRAILING_WHITESPACE ERROR_STRIP_TRAILING_WHITESPACE ERROR_QUIET)
 				if((GIT_RESULT EQUAL 0) AND (NOT "${GIT_OUTPUT}" STREQUAL ""))
 					version(MODIFY _VERSION "${_VERSION}" COMPRESS
-						TWEAK "${GIT_OUTPUT}"
-						PRERELEASE "a"
+						BUILD "${GIT_OUTPUT}"
 						REQUIRE "PATCH;TWEAK"
 					)
-
-					execute_process(COMMAND "${GIT}" log -1 "--pretty=format:g%h" --abbrev=8 HEAD WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR} RESULT_VARIABLE GIT_RESULT OUTPUT_VARIABLE GIT_OUTPUT ERROR_VARIABLE GIT_ERROR OUTPUT_STRIP_TRAILING_WHITESPACE ERROR_STRIP_TRAILING_WHITESPACE ERROR_QUIET)
-					if((GIT_RESULT EQUAL 0) AND (NOT "${GIT_OUTPUT}" STREQUAL ""))
-						version(MODIFY _VERSION "${_VERSION}" COMPRESS
-							BUILD "${GIT_OUTPUT}"
-							PRERELEASE "a"
-							REQUIRE "PATCH;TWEAK"
-						)
-					else()
-						message(WARNING "Failed to detect full version with 'git'.")
-					endif()
 				else()
-					message(WARNING "Failed to automatically detect version with 'git'.")
+					message(WARNING "Failed to detect build version with 'git'.")
 				endif()
+			else()
+				message(WARNING "Failed to automatically detect version with 'git'.")
 			endif()
 		endif()
 	else()

--- a/source/updater.cpp
+++ b/source/updater.cpp
@@ -152,60 +152,56 @@ bool streamfx::version_info::is_older_than(const version_info other)
 
 	// Compare Major version:
 	// - Theirs is greater: Remote is newer.
-	// - Ours is greater: Remote is older.
-	// - Continue the check.
 	if (major < other.major)
 		return true;
+	// - Ours is greater: Remote is older.
 	if (major > other.major)
 		return false;
+	// - Continue the check.
 
 	// Compare Minor version:
 	// - Theirs is greater: Remote is newer.
-	// - Ours is greater: Remote is older.
-	// - Continue the check.
 	if (minor < other.minor)
 		return true;
+	// - Ours is greater: Remote is older.
 	if (minor > other.minor)
 		return false;
+	// - Continue the check.
 
 	// Compare Patch version:
 	// - Theirs is greater: Remote is newer.
-	// - Ours is greater: Remote is older.
-	// - Continue the check.
 	if (patch < other.patch)
 		return true;
+	// - Ours is greater: Remote is older.
 	if (patch > other.patch)
 		return false;
-
-	// Compare Tweak and Stage version:
-	// - Theirs is greater: Remote is newer.
-	// - Ours is greater: Special logic.
 	// - Continue the check.
+
+	// Compare Stage
+	// - Theirs is Stable, we are not: Remote is newer.
+	if ((stage != version_stage::STABLE) && (other.stage == version_stage::STABLE))
+		return true;
+	// - Continue the check.
+
+	// Compare Tweak
+	// - Theirs is greater: Remote is newer.
 	if (tweak < other.tweak)
 		return true;
-	if ((tweak > other.tweak) && (other.stage != version_stage::STABLE)) {
-		// If the remote isn't a stable release, it's always considered older.
+	// - Ours is greater: Remote is older.
+	if (tweak > other.tweak)
 		return false;
-
-		// 0.12.0 vs 0.12.0
-		// Major: equal, continue
-		// Minor: equal, continue
-		// Patch: equal, continue
-		// Tweak: equal, continue
-		// Ours is older?
-	}
-
-	// As a last effort, compare the stage.
-	// - Theirs is greater: Remote is older.
-	// - Ours is greater: Remote is newer.
 	// - Continue the check.
-	if (stage < other.stage)
-		return false;
+
+	// Compare Stage (again)
+	// - Ours is greater: Remote is newer.
 	if (stage > other.stage)
 		return true;
-
-	// If there are no further tests, assume this version is older.
-	return true;
+	// - Theirs is greater: Remote is older.
+	if (stage < other.stage)
+		return false;
+	
+	// If all tests failed so far, assume the compared version is identical or newer.
+	return false;
 }
 
 streamfx::version_info::operator std::string()


### PR DESCRIPTION
### Explain the Pull Request
- An oversight in how versions were generated resulted in version detection failing unexpectedly.
- A similar oversight in the comparison code made it so that StreamFX would always claim the current version is older than the remote version.

#### Completion Checklist
<!-- Check all items that apply. Don't lie here, we'll know the moment we verify this. -->
- [ ] This has been tested on the following platforms: <!-- REQUIRED (at least one) -->
  - [ ] MacOS 10.15
  - [ ] MacOS 11
  - [ ] MacOS 12
  - [ ] Ubuntu 20.04
  - [ ] Ubuntu 22.04
  - [ ] Windows 10
  - [ ] Windows 11
- [ ] The copyright headers and license files have been updated. <!-- REQUIRED -->
- [ ] I will maintain this for the forseeable future, and have added myself to `CODEOWNERS`. <!-- REQUIRED for content or feature additions -->
