### PR TITLE
Fix encoder::ffmpeg attempting to create itself again

### DIFF
--- a/source/encoders/encoder-ffmpeg.hpp
+++ b/source/encoders/encoder-ffmpeg.hpp
@@ -29,7 +29,9 @@ extern "C" {
 }
 
 namespace streamfx::encoder::ffmpeg {
+	class ffmpeg_instance;
 	class ffmpeg_factory;
+	class ffmpeg_manager;
 
 	class ffmpeg_instance : public obs::encoder_instance {
 		ffmpeg_factory* _factory;
@@ -117,7 +119,7 @@ namespace streamfx::encoder::ffmpeg {
 		std::shared_ptr<handler::handler> _handler;
 
 		public:
-		ffmpeg_factory(const AVCodec* codec);
+		ffmpeg_factory(ffmpeg_manager* manager, const AVCodec* codec);
 		virtual ~ffmpeg_factory();
 
 		const char* get_name() override;


### PR DESCRIPTION
### Explain the Pull Request
Not sure why I did it any other way before - there's no benefit to the previous design, only downsides.

#### Completion Checklist
<!-- Check all items that apply. Don't lie here, we'll know the moment we verify this. -->
- [ ] This has been tested on the following platforms: <!-- REQUIRED (at least one) -->
  - [ ] MacOS 10.15
  - [ ] MacOS 11
  - [ ] MacOS 12
  - [ ] Ubuntu 20.04
  - [ ] Ubuntu 22.04
  - [ ] Windows 10
  - [ ] Windows 11
- [ ] The copyright headers and license files have been updated. <!-- REQUIRED -->
- [ ] I will maintain this for the forseeable future, and have added myself to `CODEOWNERS`. <!-- REQUIRED for content or feature additions -->
