### PR TITLE
Install to local Common Files directory, instead of local Program Files directory

### DIFF
--- a/templates/windows/installer.iss.in
+++ b/templates/windows/installer.iss.in
@@ -250,11 +250,11 @@ begin
 
 	// If this is a User install, register the necessary environment changes.
 	if (IsUserMode()) then begin
-		sPluginsPath := ExpandConstant('{userpf}\obs-studio\plugins\%module%\bin\');
+		sPluginsPath := ExpandConstant('{usercf}\obs-studio\plugins\%module%\bin\');
 		StringChangeEx(sPluginsPath, '\', '/', True);
 		RegWriteExpandStringValue(HKEY_CURRENT_USER, 'Environment', 'OBS_PLUGINS_PATH', sPluginsPath);
 
-		sPluginsDataPath := ExpandConstant('{userpf}\obs-studio\plugins\%module%\data\');
+		sPluginsDataPath := ExpandConstant('{usercf}\obs-studio\plugins\%module%\data\');
 		StringChangeEx(sPluginsDataPath, '\', '/', True);
 		RegWriteExpandStringValue(HKEY_CURRENT_USER, 'Environment', 'OBS_PLUGINS_DATA_PATH', sPluginsDataPath);
 
@@ -272,7 +272,7 @@ begin
 		// Default to ProgramData/obs-studio/@PROJECT_NAME@
 		Result := ExpandConstant('{commonappdata}\obs-studio\plugins\@PROJECT_NAME@');
 	end else if (IsUserMode()) then begin
-		Result := ExpandConstant('{userpf}\obs-studio\plugins\@PROJECT_NAME@');
+		Result := ExpandConstant('{usercf}\obs-studio\plugins\@PROJECT_NAME@');
 	end else begin
 		// If a path was given as an argument, use it.
 		if (Value <> '') then begin


### PR DESCRIPTION
### Explain the Pull Request
Local (per-user) add-ons to software should reside in "C:\Users\Username\AppData\Local\Programs\Common\", similar to System (all-users) add-ons which reside in "C:\Program Files\Common Files\".

Fixes #1049

#### Completion Checklist
<!-- Check all items that apply. Don't lie here, we'll know the moment we verify this. -->
- [ ] This has been tested on the following platforms: <!-- REQUIRED (at least one) -->
  - [ ] MacOS 10.15
  - [ ] MacOS 11
  - [ ] MacOS 12
  - [ ] Ubuntu 20.04
  - [ ] Ubuntu 22.04
  - [ ] Windows 10
  - [ ] Windows 11
- [ ] The copyright headers and license files have been updated. <!-- REQUIRED -->
- [ ] I will maintain this for the forseeable future, and have added myself to `CODEOWNERS`. <!-- REQUIRED for content or feature additions -->
