### PR TITLE
Explicitly disable treating warnings as errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1694,6 +1694,8 @@ if(D_PLATFORM_WINDOWS AND ((CMAKE_CXX_COMPILER_ID STREQUAL "MSVC") OR (CMAKE_CXX
 
 	# - Treat Warnings as Errors
 	target_compile_options(${PROJECT_NAME} PRIVATE "/Wall")
+	# - Explicitly disable treating all Warnings as Errors
+	target_compile_options(${PROJECT_NAME} PRIVATE "/WX-")
 
 	# - Disable useless warnings
 	set(DISABLED_WARNINGS


### PR DESCRIPTION
### Explain the Pull Request
As libOBS and OBS Studio unfortunately enforce treating warnings as errors, it is necessary to do the opposite. This may remove the need of having a patch for this exist at all, but I'll leave it be for now and just add this single line fix.

#### Completion Checklist
<!-- Check all items that apply. Don't lie here, we'll know the moment we verify this. -->
- [ ] This has been tested on the following platforms: <!-- REQUIRED (at least one) -->
  - [ ] MacOS 10.15
  - [ ] MacOS 11
  - [ ] MacOS 12
  - [ ] Ubuntu 20.04
  - [ ] Ubuntu 22.04
  - [ ] Windows 10
  - [x] Windows 11
- [ ] The copyright headers and license files have been updated. <!-- REQUIRED -->
- [ ] I will maintain this for the forseeable future, and have added myself to `CODEOWNERS`. <!-- REQUIRED for content or feature additions -->
