### PR TITLE
Fix link ordering for WHOLE_ARCHIVE inclusion (by @nuudlman)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1050,7 +1050,7 @@ function(streamfx_add_component COMPONENT_NAME)
 	set(COMPONENT_ALIAS "StreamFX::${COMPONENT_SANITIZED_NAME}")
 	set(COMPONENT_ALIAS "${COMPONENT_ALIAS}" PARENT_SCOPE)
 
-	streamfx_add_library(${COMPONENT_TARGET} OBJECT EXCLUDE_FROM_ALL)
+	streamfx_add_library(${COMPONENT_TARGET} STATIC EXCLUDE_FROM_ALL)
 	add_library(${COMPONENT_ALIAS} ALIAS ${COMPONENT_TARGET})
 	set_target_properties(${COMPONENT_TARGET} PROPERTIES
 		COMPONENT_LABEL "${COMPONENT_NAME}"
@@ -1059,10 +1059,7 @@ function(streamfx_add_component COMPONENT_NAME)
 	)
 
 	# Always depend on StreamFX::Core
-	target_link_libraries(${COMPONENT_TARGET} 
-		PUBLIC
-			StreamFX_Core
-	)
+	target_link_libraries(${COMPONENT_TARGET} PRIVATE $<LINK_LIBRARY:WHOLE_ARCHIVE,StreamFX_Core>)
 
 	# Register the component globally.
 	get_target_property(_DEPENDS StreamFX COMPONENT_DEPENDS)
@@ -1540,7 +1537,6 @@ while(_UNRESOLVED)
 endwhile()
 
 #- Linking
-target_link_libraries(StreamFX PUBLIC StreamFX_Core)
 foreach(_ENTITY ${_RESOLVED})
 	set(RENTITY "StreamFX_${_ENTITY}")
 	get_target_property(_DEPENDS "${RENTITY}" COMPONENT_DEPENDS)
@@ -1555,7 +1551,7 @@ foreach(_ENTITY ${_RESOLVED})
 			if(T_CHECK)
 				target_link_libraries(${RENTITY}
 					PUBLIC
-						${RENTITY2}
+						$<LINK_LIBRARY:WHOLE_ARCHIVE,${RENTITY2}>
 				)
 			endif()
 		endforeach()
@@ -1563,9 +1559,11 @@ foreach(_ENTITY ${_RESOLVED})
 
 	target_link_libraries(StreamFX
 		PRIVATE			
-			${RENTITY}
+			$<LINK_LIBRARY:WHOLE_ARCHIVE,${RENTITY}>
 	)
 endforeach()
+
+target_link_libraries(StreamFX PUBLIC $<LINK_LIBRARY:WHOLE_ARCHIVE,StreamFX_Core>)
 
 ################################################################################
 # Installation


### PR DESCRIPTION
Seems to fix the original problem. Does not address Linux binaries ballooning to insane sizes.